### PR TITLE
HIVE-111048: Vivek: Unify medication administration privilege: remove singular, reference upstream constant

### DIFF
--- a/omod/src/main/java/org/openmrs/module/ipd/web/controller/IPDScheduleController.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/controller/IPDScheduleController.java
@@ -97,8 +97,8 @@ public class IPDScheduleController extends BaseRestController {
                                                            @RequestParam(value = "visitUuid",required = false) String visitUuid,
                                                            @RequestParam(value = "view", required = false) String view) {
         try {
-            if (!Context.getUserContext().hasPrivilege(PrivilegeConstants.GET_MEDICATION_ADMINISTRATION) || !Context.getUserContext().hasPrivilege(PrivilegeConstants.GET_MEDICATION_TASKS)) {
-                return new ResponseEntity<>(RestUtil.wrapErrorResponse(new Exception(), "User doesn't have the following privilege(s) " + PrivilegeConstants.GET_MEDICATION_ADMINISTRATION+", "+PrivilegeConstants.GET_MEDICATION_TASKS), FORBIDDEN);
+            if (!Context.getUserContext().hasPrivilege(PrivilegeConstants.GET_MEDICATION_ADMINISTRATIONS) || !Context.getUserContext().hasPrivilege(PrivilegeConstants.GET_MEDICATION_TASKS)) {
+                return new ResponseEntity<>(RestUtil.wrapErrorResponse(new Exception(), "User doesn't have the following privilege(s) " + PrivilegeConstants.GET_MEDICATION_ADMINISTRATIONS+", "+PrivilegeConstants.GET_MEDICATION_TASKS), FORBIDDEN);
             }
 ;            if (startTime != null && endTime != null) {
                 LocalDateTime localStartDate = convertEpocUTCToLocalTimeZone(startTime);
@@ -122,8 +122,8 @@ public class IPDScheduleController extends BaseRestController {
                                                                  @RequestParam(value = "serviceType", required = false) ServiceType serviceType,
                                                                  @RequestParam(value = "orderUuids", required = false) List<String> orderUuids) {
         try {
-            if (!Context.getUserContext().hasPrivilege(PrivilegeConstants.GET_MEDICATION_ADMINISTRATION) || !Context.getUserContext().hasPrivilege(PrivilegeConstants.GET_MEDICATION_TASKS)) {
-                return new ResponseEntity<>(RestUtil.wrapErrorResponse(new Exception(), "User doesn't have the following privilege(s) " + PrivilegeConstants.GET_MEDICATION_ADMINISTRATION+" "+PrivilegeConstants.GET_MEDICATION_TASKS), FORBIDDEN);
+            if (!Context.getUserContext().hasPrivilege(PrivilegeConstants.GET_MEDICATION_ADMINISTRATIONS) || !Context.getUserContext().hasPrivilege(PrivilegeConstants.GET_MEDICATION_TASKS)) {
+                return new ResponseEntity<>(RestUtil.wrapErrorResponse(new Exception(), "User doesn't have the following privilege(s) " + PrivilegeConstants.GET_MEDICATION_ADMINISTRATIONS+" "+PrivilegeConstants.GET_MEDICATION_TASKS), FORBIDDEN);
             }
             List<Slot> slots;
             if (orderUuids == null || orderUuids.isEmpty()) {

--- a/omod/src/main/java/org/openmrs/module/ipd/web/controller/IPDVisitController.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/controller/IPDVisitController.java
@@ -42,8 +42,8 @@ public class IPDVisitController extends BaseRestController {
     public ResponseEntity<Object> getVisitWiseMedications (
             @PathVariable("visitUuid") String visitUuid,
             @RequestParam(value = "includes", required = false) List<String> includes) throws ParseException {
-            if (!Context.getUserContext().hasPrivilege(PrivilegeConstants.GET_MEDICATION_ADMINISTRATION) || !Context.getUserContext().hasPrivilege(PrivilegeConstants.GET_MEDICATION_TASKS)) {
-                return new ResponseEntity<>(RestUtil.wrapErrorResponse(new Exception(), "User doesn't have the following privilege(s) " + PrivilegeConstants.GET_MEDICATION_ADMINISTRATION + ", " + PrivilegeConstants.GET_MEDICATION_TASKS), FORBIDDEN);
+            if (!Context.getUserContext().hasPrivilege(PrivilegeConstants.GET_MEDICATION_ADMINISTRATIONS) || !Context.getUserContext().hasPrivilege(PrivilegeConstants.GET_MEDICATION_TASKS)) {
+                return new ResponseEntity<>(RestUtil.wrapErrorResponse(new Exception(), "User doesn't have the following privilege(s) " + PrivilegeConstants.GET_MEDICATION_ADMINISTRATIONS + ", " + PrivilegeConstants.GET_MEDICATION_TASKS), FORBIDDEN);
             }
             List<IPDDrugOrder> prescribedOrders = ipdVisitService.getPrescribedOrders(visitUuid, true, null, null, null, false);
             List<IPDDrugOrderResponse> prescribedOrderResponse = prescribedOrders.stream().map(IPDDrugOrderResponse::createFrom).collect(Collectors.toList());

--- a/omod/src/main/java/org/openmrs/module/ipd/web/util/PrivilegeConstants.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/util/PrivilegeConstants.java
@@ -10,10 +10,8 @@ public class PrivilegeConstants {
     public static final String DELETE_MEDICATION_TASKS = "Delete Medication Tasks";
     @AddOnStartup(description = "Edit adhoc medication tasks description")
     public static final String EDIT_ADHOC_MEDICATION_TASKS = "Edit adhoc medication tasks";
-    @AddOnStartup(description = "Edit Medication Administration description")
-    public static final String EDIT_MEDICATION_ADMINISTRATION = "Edit Medication Administration";
-    @AddOnStartup(description = "Get Medication Administration description")
-    public static final String GET_MEDICATION_ADMINISTRATION = "Get Medication Administration";
+    public static final String EDIT_MEDICATION_ADMINISTRATION = org.openmrs.module.medicationadministration.util.PrivilegeConstants.EDIT_MEDICATION_ADMINISTRATION;
+    public static final String GET_MEDICATION_ADMINISTRATIONS = org.openmrs.module.medicationadministration.util.PrivilegeConstants.GET_MEDICATION_ADMINISTRATIONS;
     @AddOnStartup(description = "Get Medication Tasks description")
     public static final String GET_MEDICATION_TASKS = "Get Medication Tasks";
     @AddOnStartup(description = "Approve Amend Note description")

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -37,14 +37,6 @@
 		<description>Allows to Edit Emergency Medication Tasks</description>
 	</privilege>
 	<privilege>
-		<name>Edit Medication Administration</name>
-		<description>Allows to Edit Medication Administrations</description>
-	</privilege>
-	<privilege>
-		<name>Get Medication Administration</name>
-		<description>Allows to Get Medication Administrations</description>
-	</privilege>
-	<privilege>
 		<name>Get Medication Tasks</name>
 		<description>Allows to Get Medication Tasks</description>
 	</privilege>


### PR DESCRIPTION
## Summary
- Removed `<privilege>` blocks for `Get Medication Administration` (singular) and `Edit Medication Administration` from `config.xml` — ownership transferred to openmrs-module-medicationadministration
- Renamed constant `GET_MEDICATION_ADMINISTRATION` → `GET_MEDICATION_ADMINISTRATIONS` and updated all three `hasPrivilege()` call sites in `IPDScheduleController` and `IPDVisitController`
- Both `GET_MEDICATION_ADMINISTRATIONS` and `EDIT_MEDICATION_ADMINISTRATION` in `PrivilegeConstants.java` now reference `org.openmrs.module.medicationadministration.util.PrivilegeConstants` via fully qualified name, providing compile-time safety
- Removed `@AddOnStartup` from both constants — privilege registration is owned by the medicationadministration module

## Why fully qualified reference instead of import
ipd's own class is also named `PrivilegeConstants`, so a simple import would cause a name clash. The fully qualified reference `org.openmrs.module.medicationadministration.util.PrivilegeConstants` resolves unambiguously since it is in a module-namespaced package with no shadowing from OpenMRS core.

## Dependency requirement
Requires openmrs-module-medicationadministration to be built and installed (`mvn install`) before building this module, so the updated JAR with the new `PrivilegeConstants` location is available on the classpath.

## Related PRs
- [openmrs-module-medicationadministration #5](https://github.com/cureinternational/openmrs-module-medicationadministration/pull/5) — must be merged and released first
- [cure-bahmni-emr #641](https://github.com/cureinternational/cure-bahmni-emr/pull/641) — roles.csv updated to use unified privilege name

## Test plan
- [ ] `mvn clean package` passes after installing updated medicationadministration JAR
- [ ] Users with `Get Medication Administrations` privilege can access `GET /ipd/schedule/type/medication` and `GET /ipd/visit/{uuid}/medication`
- [ ] Users without the privilege receive `403 FORBIDDEN`
- [ ] Users with `Edit Medication Administration` privilege can create/update medication administrations via `IPDMedicationAdministrationController`

🤖 Generated with [Claude Code](https://claude.com/claude-code)