### PR TITLE
HIVE-111216: Vivek:  update fhir2Extension Maven coordinates to fhir2-extension

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -147,13 +147,13 @@
 
 		<dependency>
 			<groupId>org.bahmni.module</groupId>
-			<artifactId>fhir2Extension-api</artifactId>
+			<artifactId>fhir2-extension-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.bahmni.module</groupId>
-			<artifactId>fhir2Extension-omod</artifactId>
+			<artifactId>fhir2-extension-omod</artifactId>
 			<scope>provided</scope>
 		</dependency>
 

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -125,13 +125,13 @@
 
 		<dependency>
 			<groupId>org.bahmni.module</groupId>
-			<artifactId>fhir2Extension-api</artifactId>
+			<artifactId>fhir2-extension-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.bahmni.module</groupId>
-			<artifactId>fhir2Extension-omod</artifactId>
+			<artifactId>fhir2-extension-omod</artifactId>
 			<scope>provided</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 		<jacocoVersion>0.7.9</jacocoVersion>
 		<lombokVersion>1.18.26</lombokVersion>
 		<openmrsFhir2Version>2.1.0</openmrsFhir2Version>
-		<fhir2ExtensionVersion>1.4.0-SNAPSHOT</fhir2ExtensionVersion>
+		<fhir2ExtensionVersion>1.4.0.ipd-SNAPSHOT</fhir2ExtensionVersion>
 		<bahmniVersion>1.2.0</bahmniVersion>
 		<emrapi-omod.version>1.36.0</emrapi-omod.version>
 		<medicationAdminstrationVersion>2.0.0.ipd-SNAPSHOT</medicationAdminstrationVersion>
@@ -231,7 +231,7 @@
 
 			<dependency>
 				<groupId>org.bahmni.module</groupId>
-				<artifactId>fhir2Extension-api</artifactId>
+				<artifactId>fhir2-extension-api</artifactId>
 				<version>${fhir2ExtensionVersion}</version>
 				<scope>provided</scope>
 			</dependency>
@@ -239,7 +239,7 @@
 
 			<dependency>
 				<groupId>org.bahmni.module</groupId>
-				<artifactId>fhir2Extension-omod</artifactId>
+				<artifactId>fhir2-extension-omod</artifactId>
 				<version>${fhir2ExtensionVersion}</version>
 				<scope>provided</scope>
 			</dependency>


### PR DESCRIPTION
## Summary

Updates Maven dependency coordinates for `fhir2Extension` following the rename in [openmrs-module-fhir2Extension#3](https://github.com/cureinternational/openmrs-module-fhir2Extension/pull/3).

## Changes

| File | Before | After |
|---|---|---|
| `pom.xml`, `api/pom.xml`, `omod/pom.xml` | `fhir2Extension-api` | `fhir2-extension-api` |
| `pom.xml`, `api/pom.xml`, `omod/pom.xml` | `fhir2Extension-omod` | `fhir2-extension-omod` |
| `pom.xml` | `fhir2ExtensionVersion=1.4.0-SNAPSHOT` | `fhir2ExtensionVersion=1.4.0.ipd-SNAPSHOT` |

## Why

GitHub Packages Maven registry enforces lowercase package names. `fhir2Extension` (camelCase) caused a persistent `422 Unprocessable Entity` on every deploy attempt. The `openmrs-module-fhir2Extension` CURE fork renamed its `artifactId` from `fhir2Extension` → `fhir2-extension` to fix this.

> Note: `config.xml` `require_module` (`org.bahmni.module.fhir2Extension`) is unchanged — that is the OpenMRS module ID, not a Maven coordinate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)