### PR TITLE
HIVE-111216: Fix fhir2-extension require_module ID in config.xml

### DIFF
--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -15,7 +15,7 @@
 		<require_module>org.bahmni.module.bahmnicore</require_module>
 		<require_module>org.openmrs.module.bedmanagement</require_module>
 		<require_module>org.bahmni.module.medication-administration</require_module>
-		<require_module>org.bahmni.module.fhir2Extension</require_module>
+		<require_module>org.bahmni.module.fhir2-extension</require_module>
 	</require_modules>
 
 	<globalProperty>


### PR DESCRIPTION
## Summary

- Updates `require_module` in `omod/src/main/resources/config.xml` from `org.bahmni.module.fhir2Extension` to `org.bahmni.module.fhir2-extension`
- Follows up on #21 which renamed the Maven coordinates from `fhir2Extension` to `fhir2-extension` but missed the OpenMRS module ID in `config.xml`
- Fixes the startup error: _"Module Bahmni IPD cannot be started because it requires the following module(s): org.bahmni.module.fhir2Extension"_

## Test plan

- [ ] Deploy the built `.omod` alongside the renamed `fhir2-extension` module and verify Bahmni IPD starts without the missing-module error
- [ ] CI (`validate_pr.yml`) builds cleanly with `./mvnw clean package`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)