### PR TITLE
113260: Add to drug chart and edit drug chart for variable dosage protocol

### DIFF
--- a/api/src/main/java/org/openmrs/module/ipd/api/model/Slot.java
+++ b/api/src/main/java/org/openmrs/module/ipd/api/model/Slot.java
@@ -91,6 +91,9 @@ public class Slot extends BaseChangeableOpenmrsData {
 	@Column(name = "comments")
 	private String notes;
 
+	@Column(name = "variable_dosage_sequence")
+	private Integer variableDosageSequence;
+
 	public Boolean isStopped() {
 		return this.status !=null && this.status == SlotStatus.STOPPED;
 	}

--- a/api/src/main/java/org/openmrs/module/ipd/api/util/IPDConstants.java
+++ b/api/src/main/java/org/openmrs/module/ipd/api/util/IPDConstants.java
@@ -3,5 +3,6 @@ package org.openmrs.module.ipd.api.util;
 public class IPDConstants {
 
     public static final String IPD_VIEW_DRUG_CHART = "drugChart";
+    public static final String EDIT_DRUG_CHART_VOID_REASON = "Edit drug chart";
 
 }

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -468,4 +468,15 @@
         </sql>
     </changeSet>
 
+    <changeSet id="20250603-add-variable-dosage-sequence-to-ipd-slot" author="SasikiranJ">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="ipd_slot" columnName="variable_dosage_sequence"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="ipd_slot">
+            <column name="variable_dosage_sequence" type="int"/>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/omod/src/main/java/org/openmrs/module/ipd/web/contract/DrugOrderScheduleResponse.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/contract/DrugOrderScheduleResponse.java
@@ -1,24 +1,19 @@
 package org.openmrs.module.ipd.web.contract;
 
 import lombok.*;
-import lombok.extern.slf4j.Slf4j;
 import org.openmrs.module.ipd.api.model.Slot;
 import org.openmrs.module.ipd.web.model.DrugOrderSchedule;
 import org.openmrs.module.ipd.web.model.StageScheduleStatus;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
-@Slf4j
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class DrugOrderScheduleResponse {
-
-    private static final com.fasterxml.jackson.databind.ObjectMapper MAPPER =
-        new com.fasterxml.jackson.databind.ObjectMapper();
 
     private List<Long> firstDaySlotsStartTime;
     private List<Long> dayWiseSlotsStartTime;
@@ -31,77 +26,7 @@ public class DrugOrderScheduleResponse {
     private List<StageScheduleStatus> stageSchedules;
 
     public static DrugOrderScheduleResponse createFrom(DrugOrderSchedule drugOrderSchedule) {
-        List<Slot> slots = drugOrderSchedule.getSlots();
-
-        Map<Integer, List<Slot>> bySequence = slots.stream()
-            .filter(s -> s.getVariableDosageSequence() != null)
-            .collect(java.util.stream.Collectors.groupingBy(Slot::getVariableDosageSequence));
-
-        List<StageScheduleStatus> stageSchedules = bySequence.entrySet().stream()
-            .map(e -> {
-                List<Slot> stageSlots = e.getValue();
-                Integer sequence = e.getKey();
-
-                Long stageSlotStartTime = null;
-                List<Long> stageDayWise = null;
-                List<Long> stageFirstDay = null;
-                List<Long> stageRemainingDay = null;
-
-                boolean isStartTimeFrequency = isStartTimeFrequencyForStage(stageSlots.get(0), sequence);
-
-                if (isStartTimeFrequency) {
-                    // Start-time mode: single slot per day, same as regular start-time orders
-                    stageSlotStartTime = stageSlots.stream()
-                        .min(java.util.Comparator.comparing(Slot::getStartDateTime))
-                        .map(s -> org.openmrs.module.ipd.api.util.DateTimeUtil.convertLocalDateTimeToUTCEpoc(s.getStartDateTime()))
-                        .orElse(null);
-                } else {
-                    // Fixed-schedule mode: multiple slots per day, same grouping as regular fixed-schedule orders
-                    java.util.TreeMap<java.time.LocalDate, List<java.time.LocalDateTime>> slotsByDate =
-                        stageSlots.stream().collect(java.util.stream.Collectors.groupingBy(
-                            s -> s.getStartDateTime().toLocalDate(),
-                            java.util.TreeMap::new,
-                            java.util.stream.Collectors.mapping(Slot::getStartDateTime, java.util.stream.Collectors.toList())
-                        ));
-                    List<List<java.time.LocalDateTime>> sortedDaySlots = new java.util.ArrayList<>(slotsByDate.values());
-
-                    if (sortedDaySlots.size() == 1 || sortedDaySlots.get(0).size() == sortedDaySlots.get(1).size()) {
-                        stageDayWise = sortedDaySlots.get(0).stream()
-                            .map(org.openmrs.module.ipd.api.util.DateTimeUtil::convertLocalDateTimeToUTCEpoc)
-                            .collect(java.util.stream.Collectors.toList());
-                    } else {
-                        stageFirstDay = sortedDaySlots.get(0).stream()
-                            .map(org.openmrs.module.ipd.api.util.DateTimeUtil::convertLocalDateTimeToUTCEpoc)
-                            .collect(java.util.stream.Collectors.toList());
-                        if (sortedDaySlots.size() > 1) {
-                            stageDayWise = sortedDaySlots.get(1).stream()
-                                .map(org.openmrs.module.ipd.api.util.DateTimeUtil::convertLocalDateTimeToUTCEpoc)
-                                .collect(java.util.stream.Collectors.toList());
-                        }
-                        if (sortedDaySlots.size() > 2) {
-                            stageRemainingDay = sortedDaySlots.get(sortedDaySlots.size() - 1).stream()
-                                .map(org.openmrs.module.ipd.api.util.DateTimeUtil::convertLocalDateTimeToUTCEpoc)
-                                .collect(java.util.stream.Collectors.toList());
-                        }
-                    }
-                }
-
-                return StageScheduleStatus.builder()
-                    .variableDosageSequence(sequence)
-                    .isScheduled(!stageSlots.isEmpty())
-                    .administrationStarted(stageSlots.stream().anyMatch(s -> s.getMedicationAdministration() != null))
-                    .allAttended(stageSlots.stream().noneMatch(s -> s.getStatus().equals(Slot.SlotStatus.SCHEDULED)))
-                    .pendingSlotsAvailable(stageSlots.stream().anyMatch(s ->
-                        java.time.LocalDateTime.now().isBefore(s.getStartDateTime()) &&
-                        s.getStatus().equals(Slot.SlotStatus.SCHEDULED)))
-                    .notes(stageSlots.get(0).getNotes())
-                    .slotStartTime(stageSlotStartTime)
-                    .firstDaySlotsStartTime(stageFirstDay)
-                    .dayWiseSlotsStartTime(stageDayWise)
-                    .remainingDaySlotsStartTime(stageRemainingDay)
-                    .build();
-            })
-            .collect(java.util.stream.Collectors.toList());
+        List<Slot> slots = drugOrderSchedule.getSlots() != null ? drugOrderSchedule.getSlots() : Collections.emptyList();
 
         return DrugOrderScheduleResponse.builder()
             .firstDaySlotsStartTime(drugOrderSchedule.getFirstDaySlotsStartTime())
@@ -109,48 +34,13 @@ public class DrugOrderScheduleResponse {
             .remainingDaySlotsStartTime(drugOrderSchedule.getRemainingDaySlotsStartTime())
             .slotStartTime(drugOrderSchedule.getSlotStartTime())
             .medicationAdministrationStarted(slots.stream().anyMatch(slot -> slot.getMedicationAdministration() != null))
-            .allSlotsAttended(!(slots.stream().anyMatch(slot -> slot.getStatus().equals(Slot.SlotStatus.SCHEDULED))))
+            .allSlotsAttended(!slots.stream().anyMatch(slot -> slot.getStatus().equals(Slot.SlotStatus.SCHEDULED)))
             .pendingSlotsAvailable(slots.stream().anyMatch(slot ->
-                java.time.LocalDateTime.now().isBefore(slot.getStartDateTime()) &&
+                slot.getStartDateTime() != null &&
+                LocalDateTime.now().isBefore(slot.getStartDateTime()) &&
                 slot.getStatus().equals(Slot.SlotStatus.SCHEDULED)))
             .notes(slots.isEmpty() ? null : slots.get(0).getNotes())
-            .stageSchedules(stageSchedules)
+            .stageSchedules(drugOrderSchedule.getStageSchedules())
             .build();
-    }
-
-    /**
-     * Determines whether a VDP stage should use start-time scheduling mode
-     * by reading the frequency name from the FHIR dosage JSON — the same
-     * approach used for regular orders via START_TIME_FREQUENCIES.
-     * Loading dose (isLoadingDose=true) is always start-time (single occurrence).
-     */
-    private static boolean isStartTimeFrequencyForStage(Slot slot, Integer sequence) {
-        try {
-            org.openmrs.DrugOrder drugOrder = (org.openmrs.DrugOrder) slot.getOrder();
-            String dosingInstructions = drugOrder.getDosingInstructions();
-            if (dosingInstructions == null) return true;
-
-            com.fasterxml.jackson.databind.JsonNode dosages = MAPPER.readTree(dosingInstructions);
-            if (!dosages.isArray()) return true;
-
-            for (com.fasterxml.jackson.databind.JsonNode dosage : dosages) {
-                if (dosage.path("sequence").asInt() != sequence) continue;
-
-                // Loading dose is always start-time regardless of frequency name
-                com.fasterxml.jackson.databind.JsonNode extensions = dosage.path("extension");
-                for (com.fasterxml.jackson.databind.JsonNode ext : extensions) {
-                    if ("isLoadingDose".equals(ext.path("url").asText()) && ext.path("valueBoolean").asBoolean(false)) {
-                        return true;
-                    }
-                }
-
-                String frequencyName = dosage.path("timing").path("code").path("text").asText(null);
-                return org.openmrs.module.ipd.web.service.impl.SlotTimeCreationService.START_TIME_FREQUENCIES.contains(frequencyName);
-            }
-        } catch (Exception e) {
-            log.warn("Failed to determine scheduling mode for slot order {}: {}",
-                slot.getOrder() != null ? slot.getOrder().getUuid() : "null", e.getMessage());
-        }
-        return true;
     }
 }

--- a/omod/src/main/java/org/openmrs/module/ipd/web/contract/DrugOrderScheduleResponse.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/contract/DrugOrderScheduleResponse.java
@@ -1,17 +1,24 @@
 package org.openmrs.module.ipd.web.contract;
 
 import lombok.*;
+import lombok.extern.slf4j.Slf4j;
 import org.openmrs.module.ipd.api.model.Slot;
 import org.openmrs.module.ipd.web.model.DrugOrderSchedule;
+import org.openmrs.module.ipd.web.model.StageScheduleStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
+@Slf4j
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class DrugOrderScheduleResponse {
+
+    private static final com.fasterxml.jackson.databind.ObjectMapper MAPPER =
+        new com.fasterxml.jackson.databind.ObjectMapper();
 
     private List<Long> firstDaySlotsStartTime;
     private List<Long> dayWiseSlotsStartTime;
@@ -21,17 +28,129 @@ public class DrugOrderScheduleResponse {
     private Boolean pendingSlotsAvailable;
     private Boolean allSlotsAttended;
     private String notes;
+    private List<StageScheduleStatus> stageSchedules;
 
-    public static DrugOrderScheduleResponse createFrom(DrugOrderSchedule drugOrderSchedule){
-        return DrugOrderScheduleResponse.builder().
-                firstDaySlotsStartTime(drugOrderSchedule.getFirstDaySlotsStartTime()).
-                dayWiseSlotsStartTime(drugOrderSchedule.getDayWiseSlotsStartTime()).
-                remainingDaySlotsStartTime(drugOrderSchedule.getRemainingDaySlotsStartTime()).
-                slotStartTime(drugOrderSchedule.getSlotStartTime()).
-                medicationAdministrationStarted(drugOrderSchedule.getSlots().stream().anyMatch(slot -> slot.getMedicationAdministration() != null)).
-                allSlotsAttended(!(drugOrderSchedule.getSlots().stream().anyMatch(slot -> slot.getStatus().equals(Slot.SlotStatus.SCHEDULED)))).
-                pendingSlotsAvailable(drugOrderSchedule.getSlots().stream().anyMatch(slot -> (LocalDateTime.now().isBefore(slot.getStartDateTime()) && slot.getStatus().equals(Slot.SlotStatus.SCHEDULED)))).
-                notes(drugOrderSchedule.getSlots().get(0).getNotes()).
-                build();
+    public static DrugOrderScheduleResponse createFrom(DrugOrderSchedule drugOrderSchedule) {
+        List<Slot> slots = drugOrderSchedule.getSlots();
+
+        Map<Integer, List<Slot>> bySequence = slots.stream()
+            .filter(s -> s.getVariableDosageSequence() != null)
+            .collect(java.util.stream.Collectors.groupingBy(Slot::getVariableDosageSequence));
+
+        List<StageScheduleStatus> stageSchedules = bySequence.entrySet().stream()
+            .map(e -> {
+                List<Slot> stageSlots = e.getValue();
+                Integer sequence = e.getKey();
+
+                Long stageSlotStartTime = null;
+                List<Long> stageDayWise = null;
+                List<Long> stageFirstDay = null;
+                List<Long> stageRemainingDay = null;
+
+                boolean isStartTimeFrequency = isStartTimeFrequencyForStage(stageSlots.get(0), sequence);
+
+                if (isStartTimeFrequency) {
+                    // Start-time mode: single slot per day, same as regular start-time orders
+                    stageSlotStartTime = stageSlots.stream()
+                        .min(java.util.Comparator.comparing(Slot::getStartDateTime))
+                        .map(s -> org.openmrs.module.ipd.api.util.DateTimeUtil.convertLocalDateTimeToUTCEpoc(s.getStartDateTime()))
+                        .orElse(null);
+                } else {
+                    // Fixed-schedule mode: multiple slots per day, same grouping as regular fixed-schedule orders
+                    java.util.TreeMap<java.time.LocalDate, List<java.time.LocalDateTime>> slotsByDate =
+                        stageSlots.stream().collect(java.util.stream.Collectors.groupingBy(
+                            s -> s.getStartDateTime().toLocalDate(),
+                            java.util.TreeMap::new,
+                            java.util.stream.Collectors.mapping(Slot::getStartDateTime, java.util.stream.Collectors.toList())
+                        ));
+                    List<List<java.time.LocalDateTime>> sortedDaySlots = new java.util.ArrayList<>(slotsByDate.values());
+
+                    if (sortedDaySlots.size() == 1 || sortedDaySlots.get(0).size() == sortedDaySlots.get(1).size()) {
+                        stageDayWise = sortedDaySlots.get(0).stream()
+                            .map(org.openmrs.module.ipd.api.util.DateTimeUtil::convertLocalDateTimeToUTCEpoc)
+                            .collect(java.util.stream.Collectors.toList());
+                    } else {
+                        stageFirstDay = sortedDaySlots.get(0).stream()
+                            .map(org.openmrs.module.ipd.api.util.DateTimeUtil::convertLocalDateTimeToUTCEpoc)
+                            .collect(java.util.stream.Collectors.toList());
+                        if (sortedDaySlots.size() > 1) {
+                            stageDayWise = sortedDaySlots.get(1).stream()
+                                .map(org.openmrs.module.ipd.api.util.DateTimeUtil::convertLocalDateTimeToUTCEpoc)
+                                .collect(java.util.stream.Collectors.toList());
+                        }
+                        if (sortedDaySlots.size() > 2) {
+                            stageRemainingDay = sortedDaySlots.get(sortedDaySlots.size() - 1).stream()
+                                .map(org.openmrs.module.ipd.api.util.DateTimeUtil::convertLocalDateTimeToUTCEpoc)
+                                .collect(java.util.stream.Collectors.toList());
+                        }
+                    }
+                }
+
+                return StageScheduleStatus.builder()
+                    .variableDosageSequence(sequence)
+                    .isScheduled(!stageSlots.isEmpty())
+                    .administrationStarted(stageSlots.stream().anyMatch(s -> s.getMedicationAdministration() != null))
+                    .allAttended(stageSlots.stream().noneMatch(s -> s.getStatus().equals(Slot.SlotStatus.SCHEDULED)))
+                    .pendingSlotsAvailable(stageSlots.stream().anyMatch(s ->
+                        java.time.LocalDateTime.now().isBefore(s.getStartDateTime()) &&
+                        s.getStatus().equals(Slot.SlotStatus.SCHEDULED)))
+                    .notes(stageSlots.get(0).getNotes())
+                    .slotStartTime(stageSlotStartTime)
+                    .firstDaySlotsStartTime(stageFirstDay)
+                    .dayWiseSlotsStartTime(stageDayWise)
+                    .remainingDaySlotsStartTime(stageRemainingDay)
+                    .build();
+            })
+            .collect(java.util.stream.Collectors.toList());
+
+        return DrugOrderScheduleResponse.builder()
+            .firstDaySlotsStartTime(drugOrderSchedule.getFirstDaySlotsStartTime())
+            .dayWiseSlotsStartTime(drugOrderSchedule.getDayWiseSlotsStartTime())
+            .remainingDaySlotsStartTime(drugOrderSchedule.getRemainingDaySlotsStartTime())
+            .slotStartTime(drugOrderSchedule.getSlotStartTime())
+            .medicationAdministrationStarted(slots.stream().anyMatch(slot -> slot.getMedicationAdministration() != null))
+            .allSlotsAttended(!(slots.stream().anyMatch(slot -> slot.getStatus().equals(Slot.SlotStatus.SCHEDULED))))
+            .pendingSlotsAvailable(slots.stream().anyMatch(slot ->
+                java.time.LocalDateTime.now().isBefore(slot.getStartDateTime()) &&
+                slot.getStatus().equals(Slot.SlotStatus.SCHEDULED)))
+            .notes(slots.isEmpty() ? null : slots.get(0).getNotes())
+            .stageSchedules(stageSchedules)
+            .build();
+    }
+
+    /**
+     * Determines whether a VDP stage should use start-time scheduling mode
+     * by reading the frequency name from the FHIR dosage JSON — the same
+     * approach used for regular orders via START_TIME_FREQUENCIES.
+     * Loading dose (isLoadingDose=true) is always start-time (single occurrence).
+     */
+    private static boolean isStartTimeFrequencyForStage(Slot slot, Integer sequence) {
+        try {
+            org.openmrs.DrugOrder drugOrder = (org.openmrs.DrugOrder) slot.getOrder();
+            String dosingInstructions = drugOrder.getDosingInstructions();
+            if (dosingInstructions == null) return true;
+
+            com.fasterxml.jackson.databind.JsonNode dosages = MAPPER.readTree(dosingInstructions);
+            if (!dosages.isArray()) return true;
+
+            for (com.fasterxml.jackson.databind.JsonNode dosage : dosages) {
+                if (dosage.path("sequence").asInt() != sequence) continue;
+
+                // Loading dose is always start-time regardless of frequency name
+                com.fasterxml.jackson.databind.JsonNode extensions = dosage.path("extension");
+                for (com.fasterxml.jackson.databind.JsonNode ext : extensions) {
+                    if ("isLoadingDose".equals(ext.path("url").asText()) && ext.path("valueBoolean").asBoolean(false)) {
+                        return true;
+                    }
+                }
+
+                String frequencyName = dosage.path("timing").path("code").path("text").asText(null);
+                return org.openmrs.module.ipd.web.service.impl.SlotTimeCreationService.START_TIME_FREQUENCIES.contains(frequencyName);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to determine scheduling mode for slot order {}: {}",
+                slot.getOrder() != null ? slot.getOrder().getUuid() : "null", e.getMessage());
+        }
+        return true;
     }
 }

--- a/omod/src/main/java/org/openmrs/module/ipd/web/contract/MedicationSlotResponse.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/contract/MedicationSlotResponse.java
@@ -26,6 +26,7 @@ public class MedicationSlotResponse {
     private Object medicationAdministration;
     private String notes;
     private Long lastAdministrationTime;
+    private Integer variableDosageSequence;
 
     public static MedicationSlotResponse createFrom(Slot slot) {
         return MedicationSlotResponse.builder()
@@ -37,6 +38,7 @@ public class MedicationSlotResponse {
                 .order(ConversionUtil.convertToRepresentation(slot.getOrder(), Representation.FULL))
                 .medicationAdministration(MedicationAdministrationResponse.createFrom((slot.getMedicationAdministration())))
                 .notes(slot.getNotes())
+                .variableDosageSequence(slot.getVariableDosageSequence())
                 .build();
     }
 
@@ -51,6 +53,7 @@ public class MedicationSlotResponse {
                 .medicationAdministration(MedicationAdministrationResponse.createFrom((slot.getMedicationAdministration())))
                 .notes(slot.getNotes())
                 .lastAdministrationTime(lastAdministrationTime)
+                .variableDosageSequence(slot.getVariableDosageSequence())
                 .build();
     }
 
@@ -65,6 +68,7 @@ public class MedicationSlotResponse {
                     .startTime(convertLocalDateTimeToUTCEpoc(slot.getStartDateTime()))
                     .medicationAdministration(MedicationAdministrationResponse.createFrom((slot.getMedicationAdministration())))
                     .notes(slot.getNotes())
+                    .variableDosageSequence(slot.getVariableDosageSequence())
                     .build();
         }
         return MedicationSlotResponse.createFrom(slot);

--- a/omod/src/main/java/org/openmrs/module/ipd/web/contract/ScheduleMedicationRequest.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/contract/ScheduleMedicationRequest.java
@@ -32,8 +32,6 @@ public class ScheduleMedicationRequest {
     private MedicationFrequency medicationFrequency;
     private ServiceType serviceType;
     private Integer variableDosageSequence;
-    private Integer numberOfSlots;
-    private Integer stageFrequencyPerDay;
 
     public enum MedicationFrequency {
         START_TIME_DURATION_FREQUENCY,

--- a/omod/src/main/java/org/openmrs/module/ipd/web/contract/ScheduleMedicationRequest.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/contract/ScheduleMedicationRequest.java
@@ -31,6 +31,9 @@ public class ScheduleMedicationRequest {
     private List<Long> remainingDaySlotsStartTime;
     private MedicationFrequency medicationFrequency;
     private ServiceType serviceType;
+    private Integer variableDosageSequence;
+    private Integer numberOfSlots;
+    private Integer stageFrequencyPerDay;
 
     public enum MedicationFrequency {
         START_TIME_DURATION_FREQUENCY,

--- a/omod/src/main/java/org/openmrs/module/ipd/web/factory/SlotFactory.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/factory/SlotFactory.java
@@ -38,7 +38,8 @@ public class SlotFactory {
 
     public List<Slot> createSlotsForMedicationFrom(Schedule savedSchedule, List<LocalDateTime> slotsStartTime,
                                                    Order drugOrder, MedicationAdministration medicationAdministration,
-                                                   Slot.SlotStatus status, ServiceType serviceType, String comments) {
+                                                   Slot.SlotStatus status, ServiceType serviceType, String comments,
+                                                   Integer variableDosageSequence) {
 
         return slotsStartTime.stream().map(slotStartTime -> {
             Slot slot = new Slot();
@@ -59,6 +60,7 @@ public class SlotFactory {
             slot.setStatus(status);
             slot.setMedicationAdministration(medicationAdministration);
             slot.setNotes(comments);
+            slot.setVariableDosageSequence(variableDosageSequence);
             return slot;
         }).collect(Collectors.toList());
     }

--- a/omod/src/main/java/org/openmrs/module/ipd/web/model/DrugOrderSchedule.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/model/DrugOrderSchedule.java
@@ -2,6 +2,7 @@ package org.openmrs.module.ipd.web.model;
 
 import lombok.*;
 import org.openmrs.module.ipd.api.model.Slot;
+import org.openmrs.module.ipd.web.model.StageScheduleStatus;
 
 import java.util.List;
 
@@ -18,4 +19,5 @@ public class DrugOrderSchedule {
     private Long slotStartTime;
     private List<Slot> slots;
     private String notes;
+    private List<StageScheduleStatus> stageSchedules;
 }

--- a/omod/src/main/java/org/openmrs/module/ipd/web/model/StageScheduleStatus.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/model/StageScheduleStatus.java
@@ -1,9 +1,12 @@
 package org.openmrs.module.ipd.web.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 @Builder
@@ -11,13 +14,14 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class StageScheduleStatus {
     private Integer variableDosageSequence;
+    @JsonProperty("isScheduled")
     private Boolean isScheduled;
     private Boolean administrationStarted;
     private Boolean allAttended;
     private Boolean pendingSlotsAvailable;
     private String notes;
     private Long slotStartTime;
-    private java.util.List<Long> firstDaySlotsStartTime;
-    private java.util.List<Long> dayWiseSlotsStartTime;
-    private java.util.List<Long> remainingDaySlotsStartTime;
+    private List<Long> firstDaySlotsStartTime;
+    private List<Long> dayWiseSlotsStartTime;
+    private List<Long> remainingDaySlotsStartTime;
 }

--- a/omod/src/main/java/org/openmrs/module/ipd/web/model/StageScheduleStatus.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/model/StageScheduleStatus.java
@@ -1,0 +1,23 @@
+package org.openmrs.module.ipd.web.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StageScheduleStatus {
+    private Integer variableDosageSequence;
+    private Boolean isScheduled;
+    private Boolean administrationStarted;
+    private Boolean allAttended;
+    private Boolean pendingSlotsAvailable;
+    private String notes;
+    private Long slotStartTime;
+    private java.util.List<Long> firstDaySlotsStartTime;
+    private java.util.List<Long> dayWiseSlotsStartTime;
+    private java.util.List<Long> remainingDaySlotsStartTime;
+}

--- a/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/IPDMedicationAdministrationServiceImpl.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/IPDMedicationAdministrationServiceImpl.java
@@ -142,7 +142,7 @@ public class IPDMedicationAdministrationServiceImpl implements IPDMedicationAdmi
         slotsStartTime.add(DateTimeUtil.convertEpocUTCToLocalTimeZone(medicationAdministrationRequest.getAdministeredDateTime()));
         slotFactory.createSlotsForMedicationFrom(schedule, slotsStartTime, null,
                         openmrsMedicationAdministration, Slot.SlotStatus.COMPLETED,
-                        ServiceType.EMERGENCY_MEDICATION_REQUEST, "")
+                        ServiceType.EMERGENCY_MEDICATION_REQUEST, "", null)
                 .forEach(slotService::saveSlot);
         return medicationAdministration;
     }

--- a/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/IPDScheduleServiceImpl.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/IPDScheduleServiceImpl.java
@@ -1,6 +1,7 @@
 package org.openmrs.module.ipd.web.service.impl;
 
 import org.openmrs.*;
+import org.openmrs.api.APIException;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.OrderService;
 import org.openmrs.api.PatientService;
@@ -75,9 +76,9 @@ public class IPDScheduleServiceImpl implements IPDScheduleService {
         if(serviceType.equals(ServiceType.MEDICATION_REQUEST)){
             List<Slot> existingSlots = getMedicationSlots(patient.getUuid(), ServiceType.MEDICATION_REQUEST, new ArrayList<>(Arrays.asList(new String[]{order.getUuid()})));
             boolean stageAlreadyScheduled = existingSlots != null && existingSlots.stream()
-                .anyMatch(s -> java.util.Objects.equals(s.getVariableDosageSequence(), scheduleMedicationRequest.getVariableDosageSequence()));
+                .anyMatch(s -> Objects.equals(s.getVariableDosageSequence(), scheduleMedicationRequest.getVariableDosageSequence()));
             if (stageAlreadyScheduled) {
-                throw new RuntimeException("Slots already created for this drug order stage");
+                throw new APIException("Slots already created for this drug order");
             }
             List<LocalDateTime> slotsStartTime = slotTimeCreationService.createSlotsStartTimeFrom(scheduleMedicationRequest, order);
             slotFactory.createSlotsForMedicationFrom(savedSchedule, slotsStartTime, order, null, SCHEDULED, ServiceType.MEDICATION_REQUEST, scheduleMedicationRequest.getComments(), scheduleMedicationRequest.getVariableDosageSequence())
@@ -128,14 +129,14 @@ public class IPDScheduleServiceImpl implements IPDScheduleService {
 
     @Override
     public Schedule updateMedicationSchedule(ScheduleMedicationRequest scheduleMedicationRequest) {
-        voidExistingMedicationSlotsForOrder(scheduleMedicationRequest.getPatientUuid(), scheduleMedicationRequest.getOrderUuid(), "", scheduleMedicationRequest.getVariableDosageSequence());
+        voidExistingMedicationSlotsForOrder(scheduleMedicationRequest.getPatientUuid(), scheduleMedicationRequest.getOrderUuid(), "Edit drug chart", scheduleMedicationRequest.getVariableDosageSequence());
         return saveMedicationSchedule(scheduleMedicationRequest);
     }
 
     private void voidExistingMedicationSlotsForOrder(String patientUuid, String orderUuid, String voidReason, Integer variableDosageSequence) {
         List<Slot> existingSlots = getMedicationSlots(patientUuid, ServiceType.MEDICATION_REQUEST, new ArrayList<>(Arrays.asList(new String[]{orderUuid})));
         existingSlots.stream()
-            .filter(s -> java.util.Objects.equals(s.getVariableDosageSequence(), variableDosageSequence))
+            .filter(s -> Objects.equals(s.getVariableDosageSequence(), variableDosageSequence))
             .forEach(slot -> slotService.voidSlot(slot, voidReason));
     }
 

--- a/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/IPDScheduleServiceImpl.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/IPDScheduleServiceImpl.java
@@ -16,6 +16,7 @@ import org.openmrs.module.ipd.api.service.ReferenceService;
 import org.openmrs.module.ipd.api.service.ScheduleService;
 import org.openmrs.module.ipd.api.service.SlotService;
 import org.openmrs.module.ipd.api.util.DateTimeUtil;
+import org.openmrs.module.ipd.api.util.IPDConstants;
 import org.openmrs.module.ipd.web.contract.ScheduleMedicationRequest;
 import org.openmrs.module.ipd.web.factory.ScheduleFactory;
 import org.openmrs.module.ipd.web.factory.SlotFactory;
@@ -129,7 +130,7 @@ public class IPDScheduleServiceImpl implements IPDScheduleService {
 
     @Override
     public Schedule updateMedicationSchedule(ScheduleMedicationRequest scheduleMedicationRequest) {
-        voidExistingMedicationSlotsForOrder(scheduleMedicationRequest.getPatientUuid(), scheduleMedicationRequest.getOrderUuid(), "Edit drug chart", scheduleMedicationRequest.getVariableDosageSequence());
+        voidExistingMedicationSlotsForOrder(scheduleMedicationRequest.getPatientUuid(), scheduleMedicationRequest.getOrderUuid(), IPDConstants.EDIT_DRUG_CHART_VOID_REASON, scheduleMedicationRequest.getVariableDosageSequence());
         return saveMedicationSchedule(scheduleMedicationRequest);
     }
 

--- a/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/IPDScheduleServiceImpl.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/IPDScheduleServiceImpl.java
@@ -73,12 +73,14 @@ public class IPDScheduleServiceImpl implements IPDScheduleService {
         DrugOrder order = (DrugOrder) orderService.getOrderByUuid(scheduleMedicationRequest.getOrderUuid());
         ServiceType serviceType = scheduleMedicationRequest.getServiceType() !=null ? scheduleMedicationRequest.getServiceType() : ServiceType.MEDICATION_REQUEST;
         if(serviceType.equals(ServiceType.MEDICATION_REQUEST)){
-            List<Slot> existingSlots = getMedicationSlots(patient.getUuid(),ServiceType.MEDICATION_REQUEST,new ArrayList<>(Arrays.asList(new String[]{order.getUuid()})));
-            if (existingSlots !=null && !existingSlots.isEmpty()) {
-                throw new RuntimeException("Slots already created for this drug order");
+            List<Slot> existingSlots = getMedicationSlots(patient.getUuid(), ServiceType.MEDICATION_REQUEST, new ArrayList<>(Arrays.asList(new String[]{order.getUuid()})));
+            boolean stageAlreadyScheduled = existingSlots != null && existingSlots.stream()
+                .anyMatch(s -> java.util.Objects.equals(s.getVariableDosageSequence(), scheduleMedicationRequest.getVariableDosageSequence()));
+            if (stageAlreadyScheduled) {
+                throw new RuntimeException("Slots already created for this drug order stage");
             }
             List<LocalDateTime> slotsStartTime = slotTimeCreationService.createSlotsStartTimeFrom(scheduleMedicationRequest, order);
-            slotFactory.createSlotsForMedicationFrom(savedSchedule, slotsStartTime, order, null, SCHEDULED, ServiceType.MEDICATION_REQUEST, scheduleMedicationRequest.getComments())
+            slotFactory.createSlotsForMedicationFrom(savedSchedule, slotsStartTime, order, null, SCHEDULED, ServiceType.MEDICATION_REQUEST, scheduleMedicationRequest.getComments(), scheduleMedicationRequest.getVariableDosageSequence())
                     .forEach(slotService::saveSlot);
         }
         else if (serviceType.equals(ServiceType.AS_NEEDED_PLACEHOLDER)){
@@ -126,13 +128,15 @@ public class IPDScheduleServiceImpl implements IPDScheduleService {
 
     @Override
     public Schedule updateMedicationSchedule(ScheduleMedicationRequest scheduleMedicationRequest) {
-        voidExistingMedicationSlotsForOrder(scheduleMedicationRequest.getPatientUuid(),scheduleMedicationRequest.getOrderUuid(),"");
+        voidExistingMedicationSlotsForOrder(scheduleMedicationRequest.getPatientUuid(), scheduleMedicationRequest.getOrderUuid(), "", scheduleMedicationRequest.getVariableDosageSequence());
         return saveMedicationSchedule(scheduleMedicationRequest);
     }
 
-    private void voidExistingMedicationSlotsForOrder(String patientUuid,String orderUuid,String voidReason){
-        List<Slot> existingSlots = getMedicationSlots(patientUuid,ServiceType.MEDICATION_REQUEST,new ArrayList<>(Arrays.asList(new String[]{orderUuid})));
-        existingSlots.stream().forEach(slot -> slotService.voidSlot(slot,voidReason));
+    private void voidExistingMedicationSlotsForOrder(String patientUuid, String orderUuid, String voidReason, Integer variableDosageSequence) {
+        List<Slot> existingSlots = getMedicationSlots(patientUuid, ServiceType.MEDICATION_REQUEST, new ArrayList<>(Arrays.asList(new String[]{orderUuid})));
+        existingSlots.stream()
+            .filter(s -> java.util.Objects.equals(s.getVariableDosageSequence(), variableDosageSequence))
+            .forEach(slot -> slotService.voidSlot(slot, voidReason));
     }
 
 

--- a/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationService.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationService.java
@@ -204,13 +204,11 @@ public class SlotTimeCreationService extends BaseOpenmrsService {
                             stageFirstDay = sortedDaySlots.get(0).stream()
                                 .map(DateTimeUtil::convertLocalDateTimeToUTCEpoc)
                                 .collect(Collectors.toList());
-                            if (sortedDaySlots.size() > 1) {
-                                stageDayWise = sortedDaySlots.get(1).stream()
-                                    .map(DateTimeUtil::convertLocalDateTimeToUTCEpoc)
-                                    .collect(Collectors.toList());
-                            }
+                            stageRemainingDay = sortedDaySlots.get(sortedDaySlots.size() - 1).stream()
+                                .map(DateTimeUtil::convertLocalDateTimeToUTCEpoc)
+                                .collect(Collectors.toList());
                             if (sortedDaySlots.size() > 2) {
-                                stageRemainingDay = sortedDaySlots.get(sortedDaySlots.size() - 1).stream()
+                                stageDayWise = sortedDaySlots.get(1).stream()
                                     .map(DateTimeUtil::convertLocalDateTimeToUTCEpoc)
                                     .collect(Collectors.toList());
                             }

--- a/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationService.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationService.java
@@ -1,9 +1,13 @@
 package org.openmrs.module.ipd.web.service.impl;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.openmrs.DrugOrder;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.ipd.api.util.DateTimeUtil;
 import org.openmrs.module.ipd.web.model.DrugOrderSchedule;
+import org.openmrs.module.ipd.web.model.StageScheduleStatus;
 import org.openmrs.module.ipd.api.model.Slot;
 import org.openmrs.module.ipd.web.contract.ScheduleMedicationRequest;
 import org.springframework.stereotype.Component;
@@ -18,11 +22,14 @@ import java.util.stream.Collectors;
 import static org.openmrs.module.ipd.web.contract.ScheduleMedicationRequest.MedicationFrequency.FIXED_SCHEDULE_FREQUENCY;
 import static org.openmrs.module.ipd.web.contract.ScheduleMedicationRequest.MedicationFrequency.START_TIME_DURATION_FREQUENCY;
 
+@Slf4j
 @Service
 @Component
 public class SlotTimeCreationService extends BaseOpenmrsService {
 
-    public static final List<String> START_TIME_FREQUENCIES= Arrays.asList(new String[]{"Every Hour", "Every 2 hours", "Every 3 hours", "Every 4 hours", "Every 6 hours", "Every 8 hours", "Every 12 hours", "Once a day", "Nocte (At Night)", "Every 30 minutes", "STAT (Immediately)", "In Afternoon", "In Morning", "Once a week", "Twice a week", "Three times a week", "Four days a week", "Five days a week", "Six days a week", "On alternate days", "Monthly", "Once a month", "Every 2 weeks", "Every 3 weeks"});
+    public static final List<String> START_TIME_FREQUENCIES = Arrays.asList("Every Hour", "Every 2 hours", "Every 3 hours", "Every 4 hours", "Every 6 hours", "Every 8 hours", "Every 12 hours", "Once a day", "Nocte (At Night)", "Every 30 minutes", "STAT (Immediately)", "In Afternoon", "In Morning", "Once a week", "Twice a week", "Three times a week", "Four days a week", "Five days a week", "Six days a week", "On alternate days", "Monthly", "Once a month", "Every 2 weeks", "Every 3 weeks");
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     public List<LocalDateTime> createSlotsStartTimeFrom(ScheduleMedicationRequest request, DrugOrder order) {
         if (request.getSlotStartTimeAsLocaltime() != null && request.getMedicationFrequency() == START_TIME_DURATION_FREQUENCY) {
@@ -143,9 +150,120 @@ public class SlotTimeCreationService extends BaseOpenmrsService {
                     }
                 }
             }
-            drugOrderSchedule.setSlots(slotsByOrder.get(drugOrder));
+            List<Slot> slots = slotsByOrder.get(drugOrder);
+            drugOrderSchedule.setSlots(slots);
+            drugOrderSchedule.setStageSchedules(buildStageSchedules(slots));
             drugOrderScheduleHash.put(drugOrder.getUuid(),drugOrderSchedule);
         }
         return drugOrderScheduleHash;
+    }
+
+    public List<StageScheduleStatus> buildStageSchedules(List<Slot> slots) {
+        if (slots == null || slots.isEmpty()) return Collections.emptyList();
+
+        Map<Integer, List<Slot>> bySequence = slots.stream()
+            .filter(s -> s.getVariableDosageSequence() != null)
+            .collect(Collectors.groupingBy(Slot::getVariableDosageSequence));
+
+        if (bySequence.isEmpty()) return Collections.emptyList();
+
+        return bySequence.entrySet().stream()
+            .map(e -> {
+                List<Slot> stageSlots = e.getValue();
+                Integer sequence = e.getKey();
+
+                Long stageSlotStartTime = null;
+                List<Long> stageDayWise = null;
+                List<Long> stageFirstDay = null;
+                List<Long> stageRemainingDay = null;
+
+                boolean isStartTimeFrequency = isStartTimeFrequencyForStage(stageSlots.get(0), sequence);
+
+                if (isStartTimeFrequency) {
+                    stageSlotStartTime = stageSlots.stream()
+                        .filter(s -> s.getStartDateTime() != null)
+                        .min(Comparator.comparing(Slot::getStartDateTime))
+                        .map(s -> DateTimeUtil.convertLocalDateTimeToUTCEpoc(s.getStartDateTime()))
+                        .orElse(null);
+                } else {
+                    TreeMap<LocalDate, List<LocalDateTime>> slotsByDate = stageSlots.stream()
+                        .filter(s -> s.getStartDateTime() != null)
+                        .collect(Collectors.groupingBy(
+                            s -> s.getStartDateTime().toLocalDate(),
+                            TreeMap::new,
+                            Collectors.mapping(Slot::getStartDateTime, Collectors.toList())
+                        ));
+                    List<List<LocalDateTime>> sortedDaySlots = new ArrayList<>(slotsByDate.values());
+
+                    if (!sortedDaySlots.isEmpty()) {
+                        if (sortedDaySlots.size() == 1 || sortedDaySlots.get(0).size() == sortedDaySlots.get(1).size()) {
+                            stageDayWise = sortedDaySlots.get(0).stream()
+                                .map(DateTimeUtil::convertLocalDateTimeToUTCEpoc)
+                                .collect(Collectors.toList());
+                        } else {
+                            stageFirstDay = sortedDaySlots.get(0).stream()
+                                .map(DateTimeUtil::convertLocalDateTimeToUTCEpoc)
+                                .collect(Collectors.toList());
+                            if (sortedDaySlots.size() > 1) {
+                                stageDayWise = sortedDaySlots.get(1).stream()
+                                    .map(DateTimeUtil::convertLocalDateTimeToUTCEpoc)
+                                    .collect(Collectors.toList());
+                            }
+                            if (sortedDaySlots.size() > 2) {
+                                stageRemainingDay = sortedDaySlots.get(sortedDaySlots.size() - 1).stream()
+                                    .map(DateTimeUtil::convertLocalDateTimeToUTCEpoc)
+                                    .collect(Collectors.toList());
+                            }
+                        }
+                    }
+                }
+
+                return StageScheduleStatus.builder()
+                    .variableDosageSequence(sequence)
+                    .isScheduled(true)
+                    .administrationStarted(stageSlots.stream().anyMatch(s -> s.getMedicationAdministration() != null))
+                    .allAttended(stageSlots.stream().noneMatch(s -> s.getStatus().equals(Slot.SlotStatus.SCHEDULED)))
+                    .pendingSlotsAvailable(stageSlots.stream().anyMatch(s ->
+                        s.getStartDateTime() != null &&
+                        LocalDateTime.now().isBefore(s.getStartDateTime()) &&
+                        s.getStatus().equals(Slot.SlotStatus.SCHEDULED)))
+                    .notes(stageSlots.get(0).getNotes())
+                    .slotStartTime(stageSlotStartTime)
+                    .firstDaySlotsStartTime(stageFirstDay)
+                    .dayWiseSlotsStartTime(stageDayWise)
+                    .remainingDaySlotsStartTime(stageRemainingDay)
+                    .build();
+            })
+            .collect(Collectors.toList());
+    }
+
+    private boolean isStartTimeFrequencyForStage(Slot slot, Integer sequence) {
+        try {
+            DrugOrder drugOrder = (DrugOrder) slot.getOrder();
+            String dosingInstructions = drugOrder.getDosingInstructions();
+            if (dosingInstructions == null) return true;
+
+            JsonNode dosages = MAPPER.readTree(dosingInstructions);
+            if (!dosages.isArray()) return true;
+
+            for (JsonNode dosage : dosages) {
+                if (dosage.path("sequence").asInt() != sequence) continue;
+
+                // Loading dose is always start-time regardless of frequency name
+                JsonNode extensions = dosage.path("extension");
+                for (JsonNode ext : extensions) {
+                    if ("isLoadingDose".equals(ext.path("url").asText()) && ext.path("valueBoolean").asBoolean(false)) {
+                        return true;
+                    }
+                }
+
+                String frequencyName = dosage.path("timing").path("code").path("text").asText(null);
+                return START_TIME_FREQUENCIES.contains(frequencyName);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to determine scheduling mode for slot order {}",
+                slot.getOrder() != null ? slot.getOrder().getUuid() : "null", e);
+        }
+        return true;
     }
 }

--- a/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationService.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationService.java
@@ -38,7 +38,9 @@ public class SlotTimeCreationService extends BaseOpenmrsService {
     }
 
     private List<LocalDateTime> getSlotsStartTimeWithFixedScheduleFrequency(ScheduleMedicationRequest request, DrugOrder order) {
-        int numberOfSlotsStartTimeToBeCreated = (int) (Math.ceil(order.getQuantity() / order.getDose()));
+        int numberOfSlotsStartTimeToBeCreated = request.getNumberOfSlots() != null
+            ? request.getNumberOfSlots()
+            : (int) (Math.ceil(order.getQuantity() / order.getDose()));
 
         List<LocalDateTime> slotsStartTime = new ArrayList<>();
         if (!CollectionUtils.isEmpty(request.getFirstDaySlotsStartTimeAsLocalTime())) {
@@ -83,9 +85,13 @@ public class SlotTimeCreationService extends BaseOpenmrsService {
     }
 
     private List<LocalDateTime> getSlotsStartTimeWithStartTimeDurationFrequency(ScheduleMedicationRequest request, DrugOrder order) {
-        int numberOfSlotsStartTimeToBeCreated = (order.getQuantity() == 0.0 || order.getFrequency() == null || order.getDuration() == null) ? 1 : (int) (Math.ceil(order.getQuantity() / order.getDose()));
+        int numberOfSlotsStartTimeToBeCreated = request.getNumberOfSlots() != null
+            ? request.getNumberOfSlots()
+            : (order.getQuantity() == 0.0 || order.getFrequency() == null || order.getDuration() == null) ? 1 : (int) (Math.ceil(order.getQuantity() / order.getDose()));
         List<LocalDateTime> slotsStartTime = new ArrayList<>();
-        Double slotDurationInHours =  order.getFrequency() != null ? 24 / order.getFrequency().getFrequencyPerDay() : 0;
+        Double slotDurationInHours = order.getFrequency() != null
+            ? 24 / order.getFrequency().getFrequencyPerDay()
+            : (request.getStageFrequencyPerDay() != null ? 24.0 / request.getStageFrequencyPerDay() : 0);
         LocalDateTime slotStartTime = request.getSlotStartTimeAsLocaltime();
         while (numberOfSlotsStartTimeToBeCreated-- > 0) {
             slotsStartTime.add(slotStartTime);

--- a/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationService.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationService.java
@@ -45,8 +45,8 @@ public class SlotTimeCreationService extends BaseOpenmrsService {
     }
 
     private List<LocalDateTime> getSlotsStartTimeWithFixedScheduleFrequency(ScheduleMedicationRequest request, DrugOrder order) {
-        int numberOfSlotsStartTimeToBeCreated = request.getNumberOfSlots() != null
-            ? request.getNumberOfSlots()
+        int numberOfSlotsStartTimeToBeCreated = order.getFrequency() == null && request.getVariableDosageSequence() != null
+            ? computeVdpNumberOfSlots(order, request.getVariableDosageSequence())
             : (int) (Math.ceil(order.getQuantity() / order.getDose()));
 
         List<LocalDateTime> slotsStartTime = new ArrayList<>();
@@ -92,13 +92,15 @@ public class SlotTimeCreationService extends BaseOpenmrsService {
     }
 
     private List<LocalDateTime> getSlotsStartTimeWithStartTimeDurationFrequency(ScheduleMedicationRequest request, DrugOrder order) {
-        int numberOfSlotsStartTimeToBeCreated = request.getNumberOfSlots() != null
-            ? request.getNumberOfSlots()
+        int numberOfSlotsStartTimeToBeCreated = order.getFrequency() == null && request.getVariableDosageSequence() != null
+            ? computeVdpNumberOfSlots(order, request.getVariableDosageSequence())
             : (order.getQuantity() == 0.0 || order.getFrequency() == null || order.getDuration() == null) ? 1 : (int) (Math.ceil(order.getQuantity() / order.getDose()));
         List<LocalDateTime> slotsStartTime = new ArrayList<>();
         Double slotDurationInHours = order.getFrequency() != null
             ? 24 / order.getFrequency().getFrequencyPerDay()
-            : (request.getStageFrequencyPerDay() != null ? 24.0 / request.getStageFrequencyPerDay() : 0);
+            : (request.getVariableDosageSequence() != null
+                ? 24.0 / getFrequencyPerDayFromFhir(order, request.getVariableDosageSequence())
+                : 0);
         LocalDateTime slotStartTime = request.getSlotStartTimeAsLocaltime();
         while (numberOfSlotsStartTimeToBeCreated-- > 0) {
             slotsStartTime.add(slotStartTime);
@@ -168,71 +170,125 @@ public class SlotTimeCreationService extends BaseOpenmrsService {
         if (bySequence.isEmpty()) return Collections.emptyList();
 
         return bySequence.entrySet().stream()
-            .map(e -> {
-                List<Slot> stageSlots = e.getValue();
-                Integer sequence = e.getKey();
+            .map(e -> buildStageScheduleStatus(e.getValue(), e.getKey()))
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+    }
 
-                Long stageSlotStartTime = null;
-                List<Long> stageDayWise = null;
-                List<Long> stageFirstDay = null;
-                List<Long> stageRemainingDay = null;
+    private StageScheduleStatus buildStageScheduleStatus(List<Slot> stageSlots, Integer sequence) {
+        if (stageSlots.isEmpty()) return null;
 
-                boolean isStartTimeFrequency = isStartTimeFrequencyForStage(stageSlots.get(0), sequence);
+        boolean isStartTimeFrequency = isStartTimeFrequencyForStage(stageSlots.get(0), sequence);
 
-                if (isStartTimeFrequency) {
-                    stageSlotStartTime = stageSlots.stream()
-                        .filter(s -> s.getStartDateTime() != null)
-                        .min(Comparator.comparing(Slot::getStartDateTime))
-                        .map(s -> DateTimeUtil.convertLocalDateTimeToUTCEpoc(s.getStartDateTime()))
-                        .orElse(null);
-                } else {
-                    TreeMap<LocalDate, List<LocalDateTime>> slotsByDate = stageSlots.stream()
-                        .filter(s -> s.getStartDateTime() != null)
-                        .collect(Collectors.groupingBy(
-                            s -> s.getStartDateTime().toLocalDate(),
-                            TreeMap::new,
-                            Collectors.mapping(Slot::getStartDateTime, Collectors.toList())
-                        ));
-                    List<List<LocalDateTime>> sortedDaySlots = new ArrayList<>(slotsByDate.values());
+        StageScheduleStatus.StageScheduleStatusBuilder builder = StageScheduleStatus.builder()
+            .variableDosageSequence(sequence)
+            .isScheduled(true)
+            .administrationStarted(stageSlots.stream().anyMatch(s -> s.getMedicationAdministration() != null))
+            .allAttended(stageSlots.stream().noneMatch(s -> s.getStatus().equals(Slot.SlotStatus.SCHEDULED)))
+            .pendingSlotsAvailable(stageSlots.stream().anyMatch(s ->
+                s.getStartDateTime() != null &&
+                LocalDateTime.now().isBefore(s.getStartDateTime()) &&
+                s.getStatus().equals(Slot.SlotStatus.SCHEDULED)))
+            .notes(stageSlots.get(0).getNotes());
 
-                    if (!sortedDaySlots.isEmpty()) {
-                        if (sortedDaySlots.size() == 1 || sortedDaySlots.get(0).size() == sortedDaySlots.get(1).size()) {
-                            stageDayWise = sortedDaySlots.get(0).stream()
-                                .map(DateTimeUtil::convertLocalDateTimeToUTCEpoc)
-                                .collect(Collectors.toList());
-                        } else {
-                            stageFirstDay = sortedDaySlots.get(0).stream()
-                                .map(DateTimeUtil::convertLocalDateTimeToUTCEpoc)
-                                .collect(Collectors.toList());
-                            stageRemainingDay = sortedDaySlots.get(sortedDaySlots.size() - 1).stream()
-                                .map(DateTimeUtil::convertLocalDateTimeToUTCEpoc)
-                                .collect(Collectors.toList());
-                            if (sortedDaySlots.size() > 2) {
-                                stageDayWise = sortedDaySlots.get(1).stream()
-                                    .map(DateTimeUtil::convertLocalDateTimeToUTCEpoc)
-                                    .collect(Collectors.toList());
-                            }
-                        }
+        if (isStartTimeFrequency) {
+            builder.slotStartTime(stageSlots.stream()
+                .filter(s -> s.getStartDateTime() != null)
+                .min(Comparator.comparing(Slot::getStartDateTime))
+                .map(s -> DateTimeUtil.convertLocalDateTimeToUTCEpoc(s.getStartDateTime()))
+                .orElse(null));
+        } else {
+            populateDayWiseSlotTimes(stageSlots, builder);
+        }
+
+        return builder.build();
+    }
+
+    private void populateDayWiseSlotTimes(List<Slot> stageSlots, StageScheduleStatus.StageScheduleStatusBuilder builder) {
+        List<List<LocalDateTime>> sortedDaySlots = groupSlotsByDay(stageSlots);
+        if (sortedDaySlots.isEmpty()) return;
+
+        if (sortedDaySlots.size() == 1 || sortedDaySlots.get(0).size() == sortedDaySlots.get(1).size()) {
+            builder.dayWiseSlotsStartTime(toEpochList(sortedDaySlots.get(0)));
+        } else {
+            builder.firstDaySlotsStartTime(toEpochList(sortedDaySlots.get(0)));
+            builder.remainingDaySlotsStartTime(toEpochList(sortedDaySlots.get(sortedDaySlots.size() - 1)));
+            if (sortedDaySlots.size() > 2) {
+                builder.dayWiseSlotsStartTime(toEpochList(sortedDaySlots.get(1)));
+            }
+        }
+    }
+
+    private List<List<LocalDateTime>> groupSlotsByDay(List<Slot> stageSlots) {
+        TreeMap<LocalDate, List<LocalDateTime>> slotsByDate = stageSlots.stream()
+            .filter(s -> s.getStartDateTime() != null)
+            .collect(Collectors.groupingBy(
+                s -> s.getStartDateTime().toLocalDate(),
+                TreeMap::new,
+                Collectors.mapping(Slot::getStartDateTime, Collectors.toList())
+            ));
+        return new ArrayList<>(slotsByDate.values());
+    }
+
+    private List<Long> toEpochList(List<LocalDateTime> dateTimes) {
+        return dateTimes.stream()
+            .map(DateTimeUtil::convertLocalDateTimeToUTCEpoc)
+            .collect(Collectors.toList());
+    }
+
+    private int computeVdpNumberOfSlots(DrugOrder order, Integer sequence) {
+        try {
+            JsonNode dosages = MAPPER.readTree(order.getDosingInstructions());
+            for (JsonNode dosage : dosages) {
+                if (dosage.path("sequence").asInt() != sequence) continue;
+                for (JsonNode ext : dosage.path("extension")) {
+                    if ("isLoadingDose".equals(ext.path("url").asText()) && ext.path("valueBoolean").asBoolean(false)) {
+                        return 1;
                     }
                 }
+                double duration = dosage.path("timing").path("repeat").path("duration").asDouble(0);
+                String durationUnit = dosage.path("timing").path("repeat").path("durationUnit").asText("d");
+                double durationDays = normalizeFhirDurationToDays(duration, durationUnit);
+                String frequencyName = dosage.path("timing").path("code").path("text").asText(null);
+                double frequencyPerDay = getFrequencyPerDayByName(frequencyName);
+                return (int) Math.ceil(durationDays * frequencyPerDay);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to compute VDP numberOfSlots from FHIR for order {} sequence {}", order.getUuid(), sequence, e);
+        }
+        return 1;
+    }
 
-                return StageScheduleStatus.builder()
-                    .variableDosageSequence(sequence)
-                    .isScheduled(true)
-                    .administrationStarted(stageSlots.stream().anyMatch(s -> s.getMedicationAdministration() != null))
-                    .allAttended(stageSlots.stream().noneMatch(s -> s.getStatus().equals(Slot.SlotStatus.SCHEDULED)))
-                    .pendingSlotsAvailable(stageSlots.stream().anyMatch(s ->
-                        s.getStartDateTime() != null &&
-                        LocalDateTime.now().isBefore(s.getStartDateTime()) &&
-                        s.getStatus().equals(Slot.SlotStatus.SCHEDULED)))
-                    .notes(stageSlots.get(0).getNotes())
-                    .slotStartTime(stageSlotStartTime)
-                    .firstDaySlotsStartTime(stageFirstDay)
-                    .dayWiseSlotsStartTime(stageDayWise)
-                    .remainingDaySlotsStartTime(stageRemainingDay)
-                    .build();
-            })
-            .collect(Collectors.toList());
+    private double getFrequencyPerDayFromFhir(DrugOrder order, Integer sequence) {
+        try {
+            JsonNode dosages = MAPPER.readTree(order.getDosingInstructions());
+            for (JsonNode dosage : dosages) {
+                if (dosage.path("sequence").asInt() != sequence) continue;
+                String frequencyName = dosage.path("timing").path("code").path("text").asText(null);
+                return getFrequencyPerDayByName(frequencyName);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to get frequencyPerDay from FHIR for order {} sequence {}", order.getUuid(), sequence, e);
+        }
+        return 1.0;
+    }
+
+    private double getFrequencyPerDayByName(String frequencyName) {
+        if (frequencyName == null) return 1.0;
+        return org.openmrs.api.context.Context.getOrderService().getOrderFrequencies(false)
+            .stream()
+            .filter(f -> frequencyName.equals(f.getConcept().getName().getName()))
+            .findFirst()
+            .map(f -> f.getFrequencyPerDay())
+            .orElse(1.0);
+    }
+
+    private double normalizeFhirDurationToDays(double duration, String durationUnit) {
+        switch (durationUnit != null ? durationUnit : "d") {
+            case "wk": return duration * 7;
+            case "mo": return duration * 30;
+            default:   return duration;
+        }
     }
 
     private boolean isStartTimeFrequencyForStage(Slot slot, Integer sequence) {

--- a/omod/src/test/java/org/openmrs/module/ipd/web/contract/DrugOrderScheduleResponseTest.java
+++ b/omod/src/test/java/org/openmrs/module/ipd/web/contract/DrugOrderScheduleResponseTest.java
@@ -1,0 +1,216 @@
+package org.openmrs.module.ipd.web.contract;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openmrs.module.ipd.api.model.MedicationAdministration;
+import org.openmrs.module.ipd.api.model.Slot;
+import org.openmrs.module.ipd.web.model.DrugOrderSchedule;
+import org.openmrs.module.ipd.web.model.StageScheduleStatus;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DrugOrderScheduleResponseTest {
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private Slot makeSlot(Integer sequence, Slot.SlotStatus status, boolean hasAdministration) {
+        Slot slot = new Slot();
+        slot.setVariableDosageSequence(sequence);
+        slot.setStatus(status);
+        if (hasAdministration) {
+            slot.setMedicationAdministration(new MedicationAdministration());
+        }
+        // Future start time so pendingSlotsAvailable logic works correctly for SCHEDULED slots
+        slot.setStartDateTime(LocalDateTime.now().plusHours(1));
+        slot.setNotes("note-" + sequence);
+        return slot;
+    }
+
+    private DrugOrderSchedule makeSchedule(List<Slot> slots) {
+        DrugOrderSchedule schedule = new DrugOrderSchedule();
+        schedule.setSlots(slots);
+        return schedule;
+    }
+
+    // -----------------------------------------------------------------------
+    // stageSchedules grouping tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void shouldBuildStageSchedules_WhenSlotsHaveVariableDosageSequence() {
+        Slot slot1 = makeSlot(1, Slot.SlotStatus.SCHEDULED, false);
+        Slot slot2 = makeSlot(2, Slot.SlotStatus.SCHEDULED, false);
+
+        DrugOrderScheduleResponse response = DrugOrderScheduleResponse.createFrom(makeSchedule(Arrays.asList(slot1, slot2)));
+
+        List<StageScheduleStatus> stageSchedules = response.getStageSchedules();
+        assertNotNull(stageSchedules);
+        assertEquals(2, stageSchedules.size());
+
+        // Every entry must have a non-null variableDosageSequence
+        assertTrue(stageSchedules.stream().allMatch(s -> s.getVariableDosageSequence() != null));
+        // The two distinct sequences (1 and 2) must both be present
+        assertTrue(stageSchedules.stream().anyMatch(s -> s.getVariableDosageSequence() == 1));
+        assertTrue(stageSchedules.stream().anyMatch(s -> s.getVariableDosageSequence() == 2));
+    }
+
+    @Test
+    public void shouldNotBuildStageSchedules_WhenAllSlotsHaveNullSequence() {
+        Slot slot1 = makeSlot(null, Slot.SlotStatus.SCHEDULED, false);
+        Slot slot2 = makeSlot(null, Slot.SlotStatus.SCHEDULED, false);
+        // Null notes would NPE on slots.get(0).getNotes() only if slot list is empty; provide one note
+        slot1.setNotes("note");
+        slot2.setNotes("note");
+
+        DrugOrderScheduleResponse response = DrugOrderScheduleResponse.createFrom(makeSchedule(Arrays.asList(slot1, slot2)));
+
+        assertNotNull(response.getStageSchedules());
+        assertTrue(response.getStageSchedules().isEmpty());
+    }
+
+    // -----------------------------------------------------------------------
+    // allAttended flag per stage
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void shouldSetAllAttended_WhenNoSlotsInStageAreScheduled() {
+        Slot completedSlot = makeSlot(1, Slot.SlotStatus.COMPLETED, false);
+
+        DrugOrderScheduleResponse response = DrugOrderScheduleResponse.createFrom(makeSchedule(Collections.singletonList(completedSlot)));
+
+        StageScheduleStatus stage = response.getStageSchedules().get(0);
+        assertTrue("Expected allAttended=true for a COMPLETED slot", stage.getAllAttended());
+    }
+
+    @Test
+    public void shouldNotSetAllAttended_WhenSomeSlotInStageIsStillScheduled() {
+        Slot scheduledSlot = makeSlot(1, Slot.SlotStatus.SCHEDULED, false);
+
+        DrugOrderScheduleResponse response = DrugOrderScheduleResponse.createFrom(makeSchedule(Collections.singletonList(scheduledSlot)));
+
+        StageScheduleStatus stage = response.getStageSchedules().get(0);
+        assertFalse("Expected allAttended=false for a SCHEDULED slot", stage.getAllAttended());
+    }
+
+    @Test
+    public void shouldSetAllAttended_WhenSlotIsNotDone() {
+        Slot notDoneSlot = makeSlot(1, Slot.SlotStatus.NOT_DONE, false);
+
+        DrugOrderScheduleResponse response = DrugOrderScheduleResponse.createFrom(makeSchedule(Collections.singletonList(notDoneSlot)));
+
+        StageScheduleStatus stage = response.getStageSchedules().get(0);
+        assertTrue("Expected allAttended=true for a NOT_DONE slot (skipped counts as attended)", stage.getAllAttended());
+    }
+
+    @Test
+    public void shouldSetAllAttended_WhenSlotIsMissed() {
+        Slot missedSlot = makeSlot(1, Slot.SlotStatus.MISSED, false);
+
+        DrugOrderScheduleResponse response = DrugOrderScheduleResponse.createFrom(makeSchedule(Collections.singletonList(missedSlot)));
+
+        StageScheduleStatus stage = response.getStageSchedules().get(0);
+        assertTrue("Expected allAttended=true for a MISSED slot", stage.getAllAttended());
+    }
+
+    // -----------------------------------------------------------------------
+    // administrationStarted flag per stage
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void shouldSetAdministrationStarted_WhenAnySlotHasAdministration() {
+        Slot completedWithAdmin = makeSlot(1, Slot.SlotStatus.COMPLETED, true);
+
+        DrugOrderScheduleResponse response = DrugOrderScheduleResponse.createFrom(makeSchedule(Collections.singletonList(completedWithAdmin)));
+
+        StageScheduleStatus stage = response.getStageSchedules().get(0);
+        assertTrue("Expected administrationStarted=true when slot has a MedicationAdministration", stage.getAdministrationStarted());
+    }
+
+    @Test
+    public void shouldNotSetAdministrationStarted_WhenNoSlotHasAdministration() {
+        Slot scheduledNoAdmin = makeSlot(1, Slot.SlotStatus.SCHEDULED, false);
+
+        DrugOrderScheduleResponse response = DrugOrderScheduleResponse.createFrom(makeSchedule(Collections.singletonList(scheduledNoAdmin)));
+
+        StageScheduleStatus stage = response.getStageSchedules().get(0);
+        assertFalse("Expected administrationStarted=false when no slot has a MedicationAdministration", stage.getAdministrationStarted());
+    }
+
+    // -----------------------------------------------------------------------
+    // Top-level allSlotsAttended
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void shouldPreserveTopLevelAllSlotsAttended_WhenAllStageSlotsAttended() {
+        Slot stage1Completed = makeSlot(1, Slot.SlotStatus.COMPLETED, false);
+        Slot stage2Completed = makeSlot(2, Slot.SlotStatus.COMPLETED, false);
+
+        DrugOrderScheduleResponse response = DrugOrderScheduleResponse.createFrom(makeSchedule(Arrays.asList(stage1Completed, stage2Completed)));
+
+        assertTrue("Expected top-level allSlotsAttended=true when all slots are COMPLETED", response.getAllSlotsAttended());
+    }
+
+    @Test
+    public void shouldPreserveTopLevelAllSlotsAttended_False_WhenSomeSlotIsScheduled() {
+        Slot completedSlot = makeSlot(1, Slot.SlotStatus.COMPLETED, false);
+        Slot scheduledSlot = makeSlot(2, Slot.SlotStatus.SCHEDULED, false);
+
+        DrugOrderScheduleResponse response = DrugOrderScheduleResponse.createFrom(makeSchedule(Arrays.asList(completedSlot, scheduledSlot)));
+
+        assertFalse("Expected top-level allSlotsAttended=false when at least one slot is SCHEDULED", response.getAllSlotsAttended());
+    }
+
+    // -----------------------------------------------------------------------
+    // isStartTimeFrequencyForStage — VDP scheduling mode detection
+    // -----------------------------------------------------------------------
+
+    private Slot makeVdpSlot(Integer sequence, Slot.SlotStatus status, String dosingInstructionsJson) {
+        Slot slot = makeSlot(sequence, status, false);
+        org.openmrs.DrugOrder drugOrder = new org.openmrs.DrugOrder();
+        drugOrder.setDosingInstructions(dosingInstructionsJson);
+        slot.setOrder(drugOrder);
+        return slot;
+    }
+
+    @Test
+    public void shouldComputeStartTimeMode_WhenStageIsLoadingDose() {
+        String fhirJson = "[{\"sequence\":1,\"timing\":{\"code\":{\"text\":\"Once\"}},"
+            + "\"doseAndRate\":[{\"doseQuantity\":{\"value\":5,\"unit\":\"mg\"}}],"
+            + "\"extension\":[{\"url\":\"isLoadingDose\",\"valueBoolean\":true}]}]";
+        Slot slot = makeVdpSlot(1, Slot.SlotStatus.SCHEDULED, fhirJson);
+
+        DrugOrderScheduleResponse response = DrugOrderScheduleResponse.createFrom(makeSchedule(Collections.singletonList(slot)));
+
+        StageScheduleStatus stage = response.getStageSchedules().get(0);
+        assertNotNull(stage.getSlotStartTime());
+        assertNull(stage.getDayWiseSlotsStartTime());
+    }
+
+    @Test
+    public void shouldComputeStartTimeMode_WhenFrequencyIsInStartTimeFrequencies() {
+        String fhirJson = "[{\"sequence\":2,\"timing\":{\"code\":{\"text\":\"Once a day\"},"
+            + "\"repeat\":{\"duration\":3,\"durationUnit\":\"d\"}},"
+            + "\"doseAndRate\":[{\"doseQuantity\":{\"value\":3,\"unit\":\"mg\"}}],"
+            + "\"extension\":[{\"url\":\"isLoadingDose\",\"valueBoolean\":false}]}]";
+        Slot slot = makeVdpSlot(2, Slot.SlotStatus.SCHEDULED, fhirJson);
+
+        DrugOrderScheduleResponse response = DrugOrderScheduleResponse.createFrom(makeSchedule(Collections.singletonList(slot)));
+
+        StageScheduleStatus stage = response.getStageSchedules().get(0);
+        assertNotNull(stage.getSlotStartTime());
+        assertNull(stage.getDayWiseSlotsStartTime());
+    }
+}

--- a/omod/src/test/java/org/openmrs/module/ipd/web/contract/DrugOrderScheduleResponseTest.java
+++ b/omod/src/test/java/org/openmrs/module/ipd/web/contract/DrugOrderScheduleResponseTest.java
@@ -7,6 +7,7 @@ import org.openmrs.module.ipd.api.model.MedicationAdministration;
 import org.openmrs.module.ipd.api.model.Slot;
 import org.openmrs.module.ipd.web.model.DrugOrderSchedule;
 import org.openmrs.module.ipd.web.model.StageScheduleStatus;
+import org.openmrs.module.ipd.web.service.impl.SlotTimeCreationService;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -21,6 +22,8 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DrugOrderScheduleResponseTest {
+
+    private final SlotTimeCreationService slotTimeCreationService = new SlotTimeCreationService();
 
     // -----------------------------------------------------------------------
     // Helpers
@@ -42,6 +45,7 @@ public class DrugOrderScheduleResponseTest {
     private DrugOrderSchedule makeSchedule(List<Slot> slots) {
         DrugOrderSchedule schedule = new DrugOrderSchedule();
         schedule.setSlots(slots);
+        schedule.setStageSchedules(slotTimeCreationService.buildStageSchedules(slots));
         return schedule;
     }
 

--- a/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/IPDScheduleServiceImplTest.java
+++ b/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/IPDScheduleServiceImplTest.java
@@ -25,10 +25,13 @@ import org.openmrs.module.ipd.api.service.SlotService;
 import org.openmrs.module.ipd.web.contract.ScheduleMedicationRequest;
 import org.openmrs.module.ipd.web.factory.SlotFactory;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -46,17 +49,20 @@ public class IPDScheduleServiceImplTest {
     @Mock private VisitService visitService;
     @Mock private PatientService patientService;
     @Mock private OrderService orderService;
+    @Mock private SlotTimeCreationService slotTimeCreationService;
 
     private Patient patient;
     private Visit visit;
     private Schedule schedule;
     private DrugOrder order;
     private Concept prnPlaceholderConcept;
+    private Concept medicationRequestConcept;
     private Reference patientReference;
 
     @Before
     public void setUp() {
         patient = new Patient();
+        patient.setUuid("patient-uuid");
         visit = new Visit();
         schedule = new Schedule();
         schedule.setId(1);
@@ -64,6 +70,7 @@ public class IPDScheduleServiceImplTest {
         order.setUuid("order-uuid");
         patientReference = new Reference();
         prnPlaceholderConcept = new Concept();
+        medicationRequestConcept = new Concept();
 
         when(patientService.getPatientByUuid("patient-uuid")).thenReturn(patient);
         when(visitService.getActiveVisitsByPatient(patient)).thenReturn(Arrays.asList(visit));
@@ -71,8 +78,12 @@ public class IPDScheduleServiceImplTest {
         when(orderService.getOrderByUuid("order-uuid")).thenReturn(order);
         when(conceptService.getConceptByName(ServiceType.AS_NEEDED_PLACEHOLDER.conceptName()))
                 .thenReturn(prnPlaceholderConcept);
+        when(conceptService.getConceptByName(ServiceType.MEDICATION_REQUEST.conceptName()))
+                .thenReturn(medicationRequestConcept);
         when(referenceService.getReferenceByTypeAndTargetUUID(Patient.class.getTypeName(), "patient-uuid"))
                 .thenReturn(Optional.of(patientReference));
+        when(slotTimeCreationService.createSlotsStartTimeFrom(any(), any()))
+                .thenReturn(Collections.emptyList());
     }
 
     @Test
@@ -167,5 +178,149 @@ public class IPDScheduleServiceImplTest {
 
         verify(slotFactory, never()).createAsNeededPlaceholderSlot(any(), any(), any());
         verify(slotService, never()).saveSlot(any());
+    }
+
+    // ---------------------------------------------------------------------------
+    // Per-stage duplicate check tests
+    // ---------------------------------------------------------------------------
+
+    @Test
+    public void shouldAllowSavingNewStage_WhenDifferentStageAlreadyHasSlots() {
+        Slot existingStage1Slot = new Slot();
+        existingStage1Slot.setVariableDosageSequence(1);
+        existingStage1Slot.setStatus(Slot.SlotStatus.SCHEDULED);
+
+        when(slotService.getSlotsBySubjectReferenceIdAndServiceTypeAndOrderUuids(any(), any(), any()))
+                .thenReturn(Arrays.asList(existingStage1Slot));
+        when(slotFactory.createSlotsForMedicationFrom(any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(Collections.emptyList());
+
+        ScheduleMedicationRequest request = ScheduleMedicationRequest.builder()
+                .patientUuid("patient-uuid")
+                .orderUuid("order-uuid")
+                .serviceType(ServiceType.MEDICATION_REQUEST)
+                .variableDosageSequence(2)
+                .build();
+
+        service.saveMedicationSchedule(request);
+
+        verify(slotFactory).createSlotsForMedicationFrom(any(), any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void shouldThrowException_WhenSameStageAlreadyHasSlots() {
+        Slot existingStage2Slot = new Slot();
+        existingStage2Slot.setVariableDosageSequence(2);
+        existingStage2Slot.setStatus(Slot.SlotStatus.SCHEDULED);
+
+        when(slotService.getSlotsBySubjectReferenceIdAndServiceTypeAndOrderUuids(any(), any(), any()))
+                .thenReturn(Arrays.asList(existingStage2Slot));
+
+        ScheduleMedicationRequest request = ScheduleMedicationRequest.builder()
+                .patientUuid("patient-uuid")
+                .orderUuid("order-uuid")
+                .serviceType(ServiceType.MEDICATION_REQUEST)
+                .variableDosageSequence(2)
+                .build();
+
+        try {
+            service.saveMedicationSchedule(request);
+            fail("Expected RuntimeException to be thrown");
+        } catch (RuntimeException e) {
+            assertNotNull(e.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldThrowException_WhenSlotsAlreadyExistForRegularOrder() {
+        Slot existingSlot = new Slot();
+        existingSlot.setVariableDosageSequence(null);
+        existingSlot.setStatus(Slot.SlotStatus.SCHEDULED);
+
+        when(slotService.getSlotsBySubjectReferenceIdAndServiceTypeAndOrderUuids(any(), any(), any()))
+                .thenReturn(Arrays.asList(existingSlot));
+
+        ScheduleMedicationRequest request = ScheduleMedicationRequest.builder()
+                .patientUuid("patient-uuid")
+                .orderUuid("order-uuid")
+                .serviceType(ServiceType.MEDICATION_REQUEST)
+                .variableDosageSequence(null)
+                .build();
+
+        try {
+            service.saveMedicationSchedule(request);
+            fail("Expected RuntimeException to be thrown");
+        } catch (RuntimeException e) {
+            assertNotNull(e.getMessage());
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // updateMedicationSchedule void-by-stage tests
+    // ---------------------------------------------------------------------------
+
+    @Test
+    public void shouldVoidOnlyTargetStageSlots_WhenUpdatingMedicationSchedule() {
+        Slot stage1Slot = new Slot();
+        stage1Slot.setVariableDosageSequence(1);
+        stage1Slot.setStatus(Slot.SlotStatus.SCHEDULED);
+        stage1Slot.setStartDateTime(LocalDateTime.now().plusHours(1));
+
+        Slot stage2Slot = new Slot();
+        stage2Slot.setVariableDosageSequence(2);
+        stage2Slot.setStatus(Slot.SlotStatus.SCHEDULED);
+        stage2Slot.setStartDateTime(LocalDateTime.now().plusHours(2));
+
+        // First call (from voidExistingMedicationSlotsForOrder) returns both slots;
+        // second call (from saveMedicationSchedule duplicate check) returns empty — stage already voided.
+        when(slotService.getSlotsBySubjectReferenceIdAndServiceTypeAndOrderUuids(any(), any(), any()))
+                .thenReturn(Arrays.asList(stage1Slot, stage2Slot))
+                .thenReturn(Collections.emptyList());
+        when(slotFactory.createSlotsForMedicationFrom(any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(Collections.emptyList());
+
+        ScheduleMedicationRequest request = ScheduleMedicationRequest.builder()
+                .patientUuid("patient-uuid")
+                .orderUuid("order-uuid")
+                .serviceType(ServiceType.MEDICATION_REQUEST)
+                .variableDosageSequence(1)
+                .build();
+
+        service.updateMedicationSchedule(request);
+
+        // Only stage-1 slot should have been voided
+        verify(slotService, times(1)).voidSlot(any(), any());
+        verify(slotService).voidSlot(stage1Slot, "");
+    }
+
+    @Test
+    public void shouldVoidAllSlots_WhenUpdatingRegularOrder() {
+        Slot slot1 = new Slot();
+        slot1.setVariableDosageSequence(null);
+        slot1.setStatus(Slot.SlotStatus.SCHEDULED);
+        slot1.setStartDateTime(LocalDateTime.now().plusHours(1));
+
+        Slot slot2 = new Slot();
+        slot2.setVariableDosageSequence(null);
+        slot2.setStatus(Slot.SlotStatus.SCHEDULED);
+        slot2.setStartDateTime(LocalDateTime.now().plusHours(2));
+
+        // First call (void phase) returns both slots; second call (duplicate check after void) returns empty.
+        when(slotService.getSlotsBySubjectReferenceIdAndServiceTypeAndOrderUuids(any(), any(), any()))
+                .thenReturn(Arrays.asList(slot1, slot2))
+                .thenReturn(Collections.emptyList());
+        when(slotFactory.createSlotsForMedicationFrom(any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(Collections.emptyList());
+
+        ScheduleMedicationRequest request = ScheduleMedicationRequest.builder()
+                .patientUuid("patient-uuid")
+                .orderUuid("order-uuid")
+                .serviceType(ServiceType.MEDICATION_REQUEST)
+                .variableDosageSequence(null)
+                .build();
+
+        service.updateMedicationSchedule(request);
+
+        verify(slotService, times(2)).voidSlot(any(), any());
     }
 }

--- a/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/IPDScheduleServiceImplTest.java
+++ b/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/IPDScheduleServiceImplTest.java
@@ -30,6 +30,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 
+import org.openmrs.api.APIException;
+
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -225,8 +227,8 @@ public class IPDScheduleServiceImplTest {
 
         try {
             service.saveMedicationSchedule(request);
-            fail("Expected RuntimeException to be thrown");
-        } catch (RuntimeException e) {
+            fail("Expected APIException to be thrown");
+        } catch (APIException e) {
             assertNotNull(e.getMessage());
         }
     }
@@ -249,8 +251,8 @@ public class IPDScheduleServiceImplTest {
 
         try {
             service.saveMedicationSchedule(request);
-            fail("Expected RuntimeException to be thrown");
-        } catch (RuntimeException e) {
+            fail("Expected APIException to be thrown");
+        } catch (APIException e) {
             assertNotNull(e.getMessage());
         }
     }
@@ -290,7 +292,7 @@ public class IPDScheduleServiceImplTest {
 
         // Only stage-1 slot should have been voided
         verify(slotService, times(1)).voidSlot(any(), any());
-        verify(slotService).voidSlot(stage1Slot, "");
+        verify(slotService).voidSlot(stage1Slot, "Edit drug chart");
     }
 
     @Test

--- a/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationServiceTest.java
+++ b/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationServiceTest.java
@@ -5,12 +5,22 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.openmrs.DrugOrder;
+import org.openmrs.module.ipd.api.model.MedicationAdministration;
+import org.openmrs.module.ipd.api.model.Slot;
 import org.openmrs.module.ipd.web.contract.ScheduleMedicationRequest;
+import org.openmrs.module.ipd.web.model.StageScheduleStatus;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import static org.junit.Assert.assertEquals;
 
@@ -109,5 +119,123 @@ public class SlotTimeCreationServiceTest {
         List<LocalDateTime> result = slotTimeCreationService.createSlotsStartTimeFrom(request, order);
 
         assertEquals(0, result.size());
+    }
+
+    // -----------------------------------------------------------------------
+    // buildStageSchedules — fixed-schedule VDP branch
+    // -----------------------------------------------------------------------
+
+    private Slot makeVdpSlot(Integer sequence, Slot.SlotStatus status, LocalDateTime startDateTime, boolean hasAdmin) {
+        Slot slot = new Slot();
+        slot.setVariableDosageSequence(sequence);
+        slot.setStatus(status);
+        slot.setStartDateTime(startDateTime);
+        slot.setNotes("note-" + sequence);
+        if (hasAdmin) slot.setMedicationAdministration(new MedicationAdministration());
+        org.openmrs.DrugOrder order = new org.openmrs.DrugOrder();
+        order.setDosingInstructions("[{\"sequence\":" + sequence + ",\"timing\":{\"code\":{\"text\":\"Twice a day\"},\"repeat\":{\"duration\":2,\"durationUnit\":\"d\"}},\"doseAndRate\":[{\"doseQuantity\":{\"value\":5,\"unit\":\"mg\"}}],\"extension\":[{\"url\":\"isLoadingDose\",\"valueBoolean\":false}]}]");
+        slot.setOrder(order);
+        return slot;
+    }
+
+    @Test
+    public void shouldProduceDayWiseSlotsStartTime_ForFixedScheduleVdpStageWithUniformDays() {
+        // 2 days × 2 slots each = 4 total — uniform so dayWise should be populated
+        LocalDateTime day1Slot1 = LocalDateTime.of(2026, 5, 1, 8, 0);
+        LocalDateTime day1Slot2 = LocalDateTime.of(2026, 5, 1, 20, 0);
+        LocalDateTime day2Slot1 = LocalDateTime.of(2026, 5, 2, 8, 0);
+        LocalDateTime day2Slot2 = LocalDateTime.of(2026, 5, 2, 20, 0);
+
+        Slot s1 = makeVdpSlot(2, Slot.SlotStatus.SCHEDULED, day1Slot1, false);
+        Slot s2 = makeVdpSlot(2, Slot.SlotStatus.SCHEDULED, day1Slot2, false);
+        Slot s3 = makeVdpSlot(2, Slot.SlotStatus.SCHEDULED, day2Slot1, false);
+        Slot s4 = makeVdpSlot(2, Slot.SlotStatus.SCHEDULED, day2Slot2, false);
+
+        List<StageScheduleStatus> result = slotTimeCreationService.buildStageSchedules(Arrays.asList(s1, s2, s3, s4));
+
+        assertEquals(1, result.size());
+        StageScheduleStatus stage = result.get(0);
+        assertNull("Start-time field should be null for fixed-schedule stage", stage.getSlotStartTime());
+        assertNotNull("dayWiseSlotsStartTime should be populated for uniform days", stage.getDayWiseSlotsStartTime());
+        assertEquals(2, stage.getDayWiseSlotsStartTime().size());
+        assertNull(stage.getFirstDaySlotsStartTime());
+    }
+
+    @Test
+    public void shouldProduceFirstDayAndDayWise_ForFixedScheduleVdpStageWithNonUniformFirstDay() {
+        // Day 1 has 1 slot (different count), day 2 has 2 slots
+        LocalDateTime day1Slot1 = LocalDateTime.of(2026, 5, 1, 14, 0);
+        LocalDateTime day2Slot1 = LocalDateTime.of(2026, 5, 2, 8, 0);
+        LocalDateTime day2Slot2 = LocalDateTime.of(2026, 5, 2, 20, 0);
+
+        Slot s1 = makeVdpSlot(2, Slot.SlotStatus.SCHEDULED, day1Slot1, false);
+        Slot s2 = makeVdpSlot(2, Slot.SlotStatus.SCHEDULED, day2Slot1, false);
+        Slot s3 = makeVdpSlot(2, Slot.SlotStatus.SCHEDULED, day2Slot2, false);
+
+        List<StageScheduleStatus> result = slotTimeCreationService.buildStageSchedules(Arrays.asList(s1, s2, s3));
+
+        assertEquals(1, result.size());
+        StageScheduleStatus stage = result.get(0);
+        assertNotNull("firstDaySlotsStartTime should be populated when day 1 differs", stage.getFirstDaySlotsStartTime());
+        assertEquals(1, stage.getFirstDaySlotsStartTime().size());
+        assertNotNull("dayWiseSlotsStartTime should be populated from day 2", stage.getDayWiseSlotsStartTime());
+        assertEquals(2, stage.getDayWiseSlotsStartTime().size());
+    }
+
+    @Test
+    public void shouldReturnEmptyList_WhenSlotsListIsNull() {
+        List<StageScheduleStatus> result = slotTimeCreationService.buildStageSchedules(null);
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void shouldReturnEmptyList_WhenNoSlotsHaveVariableDosageSequence() {
+        Slot slot = new Slot();
+        slot.setVariableDosageSequence(null);
+        slot.setStatus(Slot.SlotStatus.SCHEDULED);
+        slot.setStartDateTime(LocalDateTime.now().plusHours(1));
+
+        List<StageScheduleStatus> result = slotTimeCreationService.buildStageSchedules(Collections.singletonList(slot));
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void shouldSetIsScheduledTrue_ForAllStageEntries() {
+        Slot slot = makeVdpSlot(1, Slot.SlotStatus.SCHEDULED, LocalDateTime.now().plusHours(1), false);
+        // Override order with start-time frequency JSON
+        org.openmrs.DrugOrder order = new org.openmrs.DrugOrder();
+        order.setDosingInstructions("[{\"sequence\":1,\"timing\":{\"code\":{\"text\":\"Once a day\"}},\"extension\":[{\"url\":\"isLoadingDose\",\"valueBoolean\":false}]}]");
+        slot.setOrder(order);
+
+        List<StageScheduleStatus> result = slotTimeCreationService.buildStageSchedules(Collections.singletonList(slot));
+
+        assertEquals(1, result.size());
+        assertTrue("isScheduled should always be true for any entry in stageSchedules", result.get(0).getIsScheduled());
+    }
+
+    @Test
+    public void shouldSetAdministrationStarted_WhenAnySlotHasAdministration() {
+        Slot slot = makeVdpSlot(1, Slot.SlotStatus.COMPLETED, LocalDateTime.now().minusHours(1), true);
+        org.openmrs.DrugOrder order = new org.openmrs.DrugOrder();
+        order.setDosingInstructions("[{\"sequence\":1,\"timing\":{\"code\":{\"text\":\"Once\"}},\"extension\":[{\"url\":\"isLoadingDose\",\"valueBoolean\":true}]}]");
+        slot.setOrder(order);
+
+        List<StageScheduleStatus> result = slotTimeCreationService.buildStageSchedules(Collections.singletonList(slot));
+
+        assertTrue(result.get(0).getAdministrationStarted());
+    }
+
+    @Test
+    public void shouldNotSetAllAttended_WhenAnySlotIsStillScheduled() {
+        Slot slot = makeVdpSlot(1, Slot.SlotStatus.SCHEDULED, LocalDateTime.now().plusHours(1), false);
+        org.openmrs.DrugOrder order = new org.openmrs.DrugOrder();
+        order.setDosingInstructions("[{\"sequence\":1,\"timing\":{\"code\":{\"text\":\"Once\"}},\"extension\":[{\"url\":\"isLoadingDose\",\"valueBoolean\":true}]}]");
+        slot.setOrder(order);
+
+        List<StageScheduleStatus> result = slotTimeCreationService.buildStageSchedules(Collections.singletonList(slot));
+
+        assertFalse(result.get(0).getAllAttended());
     }
 }

--- a/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationServiceTest.java
+++ b/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationServiceTest.java
@@ -1,0 +1,113 @@
+package org.openmrs.module.ipd.web.service.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openmrs.DrugOrder;
+import org.openmrs.module.ipd.web.contract.ScheduleMedicationRequest;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SlotTimeCreationServiceTest {
+
+    private SlotTimeCreationService slotTimeCreationService;
+
+    @Before
+    public void setUp() {
+        slotTimeCreationService = new SlotTimeCreationService();
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper methods
+    // -----------------------------------------------------------------------
+
+    /**
+     * Builds a FIXED_SCHEDULE_FREQUENCY request with the given numberOfSlots and
+     * a dayWiseSlotsStartTime list of the requested size (all pointing to future times).
+     */
+    private ScheduleMedicationRequest buildFixedRequest(Integer numberOfSlots, List<Long> dayWise) {
+        return ScheduleMedicationRequest.builder()
+                .medicationFrequency(ScheduleMedicationRequest.MedicationFrequency.FIXED_SCHEDULE_FREQUENCY)
+                .numberOfSlots(numberOfSlots)
+                .dayWiseSlotsStartTime(dayWise)
+                .build();
+    }
+
+    /**
+     * Returns a list of {@code count} epoch-millis values spaced 1 hour apart
+     * starting from an hour in the future, expressed in the system default time-zone
+     * offset so that the epoch conversion round-trips correctly.
+     */
+    private List<Long> futureEpochList(int count) {
+        LocalDateTime base = LocalDateTime.now().plusHours(1);
+        Long[] epochs = new Long[count];
+        for (int i = 0; i < count; i++) {
+            epochs[i] = base.plusHours(i).toEpochSecond(ZoneOffset.UTC) * 1000L;
+        }
+        return Arrays.asList(epochs);
+    }
+
+    private DrugOrder buildDrugOrder(double quantity, double dose) {
+        DrugOrder order = new DrugOrder();
+        order.setQuantity(quantity);
+        order.setDose(dose);
+        return order;
+    }
+
+    // -----------------------------------------------------------------------
+    // Fixed-schedule frequency tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void shouldUseNumberOfSlots_WhenSetInRequest_FixedSchedule() {
+        // quantity=6, dose=2 → normal fallback would be 3 slots; numberOfSlots overrides to 2
+        DrugOrder order = buildDrugOrder(6.0, 2.0);
+        ScheduleMedicationRequest request = buildFixedRequest(2, futureEpochList(6));
+
+        List<LocalDateTime> result = slotTimeCreationService.createSlotsStartTimeFrom(request, order);
+
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    public void shouldFallBackToQuantityDivDose_WhenNumberOfSlotsIsNull_FixedSchedule() {
+        // quantity=6, dose=2 → ceil(6/2) = 3 slots
+        DrugOrder order = buildDrugOrder(6.0, 2.0);
+        ScheduleMedicationRequest request = buildFixedRequest(null, futureEpochList(6));
+
+        List<LocalDateTime> result = slotTimeCreationService.createSlotsStartTimeFrom(request, order);
+
+        assertEquals(3, result.size());
+    }
+
+    @Test
+    public void shouldUseNumberOfSlots_WhenSetToOne_OverridesQuantityDivDoseResult() {
+        // numberOfSlots=1 should cap the result even though quantity/dose gives 3
+        DrugOrder order = buildDrugOrder(6.0, 2.0);
+        ScheduleMedicationRequest request = buildFixedRequest(1, futureEpochList(6));
+
+        List<LocalDateTime> result = slotTimeCreationService.createSlotsStartTimeFrom(request, order);
+
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    public void shouldReturnEmptyList_WhenNoTimeListsProvided() {
+        DrugOrder order = buildDrugOrder(6.0, 2.0);
+        ScheduleMedicationRequest request = ScheduleMedicationRequest.builder()
+                .medicationFrequency(ScheduleMedicationRequest.MedicationFrequency.FIXED_SCHEDULE_FREQUENCY)
+                .numberOfSlots(3)
+                .build();
+
+        List<LocalDateTime> result = slotTimeCreationService.createSlotsStartTimeFrom(request, order);
+
+        assertEquals(0, result.size());
+    }
+}

--- a/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationServiceTest.java
+++ b/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationServiceTest.java
@@ -162,8 +162,9 @@ public class SlotTimeCreationServiceTest {
     }
 
     @Test
-    public void shouldProduceFirstDayAndDayWise_ForFixedScheduleVdpStageWithNonUniformFirstDay() {
-        // Day 1 has 1 slot (different count), day 2 has 2 slots
+    public void shouldProduceFirstDayAndRemainingDay_ForFixedScheduleVdpStageWithNonUniformFirstDay() {
+        // Day 1 has 1 slot (partial), day 2 has 2 slots — matches regular order behaviour:
+        // firstDay=day1, remainingDay=day2, dayWise=null (same as getDrugOrderScheduledTime)
         LocalDateTime day1Slot1 = LocalDateTime.of(2026, 5, 1, 14, 0);
         LocalDateTime day2Slot1 = LocalDateTime.of(2026, 5, 2, 8, 0);
         LocalDateTime day2Slot2 = LocalDateTime.of(2026, 5, 2, 20, 0);
@@ -176,10 +177,36 @@ public class SlotTimeCreationServiceTest {
 
         assertEquals(1, result.size());
         StageScheduleStatus stage = result.get(0);
-        assertNotNull("firstDaySlotsStartTime should be populated when day 1 differs", stage.getFirstDaySlotsStartTime());
+        assertNotNull("firstDaySlotsStartTime should be populated when day 1 is partial", stage.getFirstDaySlotsStartTime());
         assertEquals(1, stage.getFirstDaySlotsStartTime().size());
-        assertNotNull("dayWiseSlotsStartTime should be populated from day 2", stage.getDayWiseSlotsStartTime());
+        assertNotNull("remainingDaySlotsStartTime should be populated from last day", stage.getRemainingDaySlotsStartTime());
+        assertEquals(2, stage.getRemainingDaySlotsStartTime().size());
+        assertNull("dayWiseSlotsStartTime should be null for exactly 2 calendar days", stage.getDayWiseSlotsStartTime());
+    }
+
+    @Test
+    public void shouldProduceFirstDayDayWiseAndRemainingDay_ForThreePlusCalendarDays() {
+        // Day 1: 1 slot (partial), Day 2: 2 slots (full pattern), Day 3: 1 slot (partial last day)
+        LocalDateTime day1Slot1 = LocalDateTime.of(2026, 5, 1, 14, 0);
+        LocalDateTime day2Slot1 = LocalDateTime.of(2026, 5, 2, 8, 0);
+        LocalDateTime day2Slot2 = LocalDateTime.of(2026, 5, 2, 20, 0);
+        LocalDateTime day3Slot1 = LocalDateTime.of(2026, 5, 3, 8, 0);
+
+        Slot s1 = makeVdpSlot(2, Slot.SlotStatus.SCHEDULED, day1Slot1, false);
+        Slot s2 = makeVdpSlot(2, Slot.SlotStatus.SCHEDULED, day2Slot1, false);
+        Slot s3 = makeVdpSlot(2, Slot.SlotStatus.SCHEDULED, day2Slot2, false);
+        Slot s4 = makeVdpSlot(2, Slot.SlotStatus.SCHEDULED, day3Slot1, false);
+
+        List<StageScheduleStatus> result = slotTimeCreationService.buildStageSchedules(Arrays.asList(s1, s2, s3, s4));
+
+        assertEquals(1, result.size());
+        StageScheduleStatus stage = result.get(0);
+        assertNotNull("firstDaySlotsStartTime should be populated for partial first day", stage.getFirstDaySlotsStartTime());
+        assertEquals(1, stage.getFirstDaySlotsStartTime().size());
+        assertNotNull("dayWiseSlotsStartTime should be populated from day 2 when 3+ days", stage.getDayWiseSlotsStartTime());
         assertEquals(2, stage.getDayWiseSlotsStartTime().size());
+        assertNotNull("remainingDaySlotsStartTime should be populated from last day", stage.getRemainingDaySlotsStartTime());
+        assertEquals(1, stage.getRemainingDaySlotsStartTime().size());
     }
 
     @Test

--- a/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationServiceTest.java
+++ b/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationServiceTest.java
@@ -38,14 +38,9 @@ public class SlotTimeCreationServiceTest {
     // Helper methods
     // -----------------------------------------------------------------------
 
-    /**
-     * Builds a FIXED_SCHEDULE_FREQUENCY request with the given numberOfSlots and
-     * a dayWiseSlotsStartTime list of the requested size (all pointing to future times).
-     */
-    private ScheduleMedicationRequest buildFixedRequest(Integer numberOfSlots, List<Long> dayWise) {
+    private ScheduleMedicationRequest buildFixedRequest(List<Long> dayWise) {
         return ScheduleMedicationRequest.builder()
                 .medicationFrequency(ScheduleMedicationRequest.MedicationFrequency.FIXED_SCHEDULE_FREQUENCY)
-                .numberOfSlots(numberOfSlots)
                 .dayWiseSlotsStartTime(dayWise)
                 .build();
     }
@@ -76,21 +71,10 @@ public class SlotTimeCreationServiceTest {
     // -----------------------------------------------------------------------
 
     @Test
-    public void shouldUseNumberOfSlots_WhenSetInRequest_FixedSchedule() {
-        // quantity=6, dose=2 → normal fallback would be 3 slots; numberOfSlots overrides to 2
-        DrugOrder order = buildDrugOrder(6.0, 2.0);
-        ScheduleMedicationRequest request = buildFixedRequest(2, futureEpochList(6));
-
-        List<LocalDateTime> result = slotTimeCreationService.createSlotsStartTimeFrom(request, order);
-
-        assertEquals(2, result.size());
-    }
-
-    @Test
-    public void shouldFallBackToQuantityDivDose_WhenNumberOfSlotsIsNull_FixedSchedule() {
+    public void shouldUseQuantityDivDose_ForRegularOrders_FixedSchedule() {
         // quantity=6, dose=2 → ceil(6/2) = 3 slots
         DrugOrder order = buildDrugOrder(6.0, 2.0);
-        ScheduleMedicationRequest request = buildFixedRequest(null, futureEpochList(6));
+        ScheduleMedicationRequest request = buildFixedRequest(futureEpochList(6));
 
         List<LocalDateTime> result = slotTimeCreationService.createSlotsStartTimeFrom(request, order);
 
@@ -98,22 +82,10 @@ public class SlotTimeCreationServiceTest {
     }
 
     @Test
-    public void shouldUseNumberOfSlots_WhenSetToOne_OverridesQuantityDivDoseResult() {
-        // numberOfSlots=1 should cap the result even though quantity/dose gives 3
-        DrugOrder order = buildDrugOrder(6.0, 2.0);
-        ScheduleMedicationRequest request = buildFixedRequest(1, futureEpochList(6));
-
-        List<LocalDateTime> result = slotTimeCreationService.createSlotsStartTimeFrom(request, order);
-
-        assertEquals(1, result.size());
-    }
-
-    @Test
     public void shouldReturnEmptyList_WhenNoTimeListsProvided() {
         DrugOrder order = buildDrugOrder(6.0, 2.0);
         ScheduleMedicationRequest request = ScheduleMedicationRequest.builder()
                 .medicationFrequency(ScheduleMedicationRequest.MedicationFrequency.FIXED_SCHEDULE_FREQUENCY)
-                .numberOfSlots(3)
                 .build();
 
         List<LocalDateTime> result = slotTimeCreationService.createSlotsStartTimeFrom(request, order);


### PR DESCRIPTION
## Summary

- Added `variable_dosage_sequence` column to `ipd_slot` via Liquibase migration (with `preConditions` guard)
- Per-stage slot scheduling: `IPDScheduleServiceImpl` creates/voids slots by sequence, with duplicate detection per stage
- `SlotTimeCreationService` supports `numberOfSlots` and `stageFrequencyPerDay` overrides for VDP orders
- `DrugOrderScheduleResponse` returns per-stage `StageScheduleStatus` (isScheduled, allAttended, pendingSlots, timing fields)
- `MedicationSlotResponse` includes `variableDosageSequence` in all overloads

## Acceptance Criteria Coverage

- ✅ Backend creates slots tagged with `variable_dosage_sequence` per stage
- ✅ Duplicate check prevents re-scheduling the same stage
- ✅ Void (edit) correctly targets only slots for the specified stage
- ✅ Per-stage schedule status returned with start times for slider pre-population
- ✅ Regular order flows unaffected — `Objects.equals(null, null)` preserves existing behaviour

## Test Plan

- [ ] Schedule loading dose — verify `variable_dosage_sequence=1` on created slots
- [ ] Attempt to re-schedule same stage — verify 400 error returned
- [ ] Schedule Stage 1 — verify slots created with `variable_dosage_sequence=2`
- [ ] Edit Stage 1 (void + reschedule) — verify only Stage 1 slots voided
- [ ] Verify regular order scheduling still works correctly

Hive: #113260