### PR TITLE
117251: Enhance slot creation and edit mode for intraday medication

### DIFF
--- a/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationService.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationService.java
@@ -45,9 +45,14 @@ public class SlotTimeCreationService extends BaseOpenmrsService {
     }
 
     private List<LocalDateTime> getSlotsStartTimeWithFixedScheduleFrequency(ScheduleMedicationRequest request, DrugOrder order) {
-        int numberOfSlotsStartTimeToBeCreated = order.getFrequency() == null && request.getVariableDosageSequence() != null
-            ? computeVdpNumberOfSlots(order, request.getVariableDosageSequence())
-            : (int) (Math.ceil(order.getQuantity() / order.getDose()));
+        int numberOfSlotsStartTimeToBeCreated;
+        if (order.getFrequency() == null && request.getVariableDosageSequence() != null) {
+            numberOfSlotsStartTimeToBeCreated = computeVdpNumberOfSlots(order, request.getVariableDosageSequence());
+        } else if (order.getDose() == null && order.getFrequency() == null) {
+            numberOfSlotsStartTimeToBeCreated = getIntradayFrequencyPerDay(order) * order.getDuration();
+        } else {
+            numberOfSlotsStartTimeToBeCreated = (int) (Math.ceil(order.getQuantity() / order.getDose()));
+        }
 
         List<LocalDateTime> slotsStartTime = new ArrayList<>();
         if (!CollectionUtils.isEmpty(request.getFirstDaySlotsStartTimeAsLocalTime())) {
@@ -120,12 +125,11 @@ public class SlotTimeCreationService extends BaseOpenmrsService {
         HashMap<String, DrugOrderSchedule> drugOrderScheduleHash= new HashMap<>();
         for (DrugOrder drugOrder : slotsByOrder.keySet()) {
             DrugOrderSchedule drugOrderSchedule = new DrugOrderSchedule();
-            if (drugOrder.getAsNeeded() || drugOrder.getFrequency() == null || drugOrder.getDuration() == null || drugOrder.getQuantity() == 0.0) {
+            boolean isIntradayOrder = drugOrder.getDose() == null && drugOrder.getFrequency() == null;
+            if (drugOrder.getAsNeeded() || (drugOrder.getFrequency() == null && !isIntradayOrder) || drugOrder.getDuration() == null || drugOrder.getQuantity() == 0.0) {
                 drugOrderSchedule.setSlotStartTime(DateTimeUtil.convertLocalDateTimeToUTCEpoc(slotsByOrder.get(drugOrder).get(0).getStartDateTime()));
             }
             else {
-                Double frequencyPerDay = drugOrder.getFrequency().getFrequencyPerDay();
-                String frequency = drugOrder.getFrequency().getName();
                 Map<LocalDate, List<LocalDateTime>> groupedByDateAndEpoch = slotsByOrder.get(drugOrder).stream()
                         .collect(Collectors.groupingBy(
                                 obj -> obj.getStartDateTime().toLocalDate(),
@@ -136,9 +140,14 @@ public class SlotTimeCreationService extends BaseOpenmrsService {
                         ));
 
                 List<List<LocalDateTime>> sortedList = groupedByDateAndEpoch.entrySet().stream()
-                        .sorted(Map.Entry.comparingByKey()) // Sort by LocalDate in ascending order
-                        .map(Map.Entry::getValue) // Get the list of Longs for each entry
-                        .collect(Collectors.toList()); // Collect the list of lists into a single ArrayList
+                        .sorted(Map.Entry.comparingByKey())
+                        .map(Map.Entry::getValue)
+                        .collect(Collectors.toList());
+
+                Double frequencyPerDay = isIntradayOrder
+                    ? (double) getIntradayFrequencyPerDay(drugOrder)
+                    : drugOrder.getFrequency().getFrequencyPerDay();
+                String frequency = isIntradayOrder ? null : drugOrder.getFrequency().getName();
 
                 if (START_TIME_FREQUENCIES.contains(frequency)) {
                     drugOrderSchedule.setSlotStartTime(DateTimeUtil.convertLocalDateTimeToUTCEpoc(sortedList.get(0).get(0)));
@@ -234,6 +243,27 @@ public class SlotTimeCreationService extends BaseOpenmrsService {
         return dateTimes.stream()
             .map(DateTimeUtil::convertLocalDateTimeToUTCEpoc)
             .collect(Collectors.toList());
+    }
+
+    private int getIntradayFrequencyPerDay(DrugOrder order) {
+        try {
+            String dosingInstructions = order.getDosingInstructions();
+            if (dosingInstructions == null || dosingInstructions.trim().isEmpty()) {
+                return 1;
+            }
+            JsonNode dosing = MAPPER.readTree(dosingInstructions);
+            if (!dosing.isObject()) {
+                return 1;
+            }
+            int count = (int) Arrays.asList("morningDose", "afternoonDose", "eveningDose", "nightDose")
+                .stream()
+                .filter(field -> dosing.path(field).asDouble(0) != 0)
+                .count();
+            return count > 0 ? count : 1;
+        } catch (Exception e) {
+            log.warn("Failed to derive intraday frequency per day for order {}", order.getUuid(), e);
+            return 1;
+        }
     }
 
     private int computeVdpNumberOfSlots(DrugOrder order, Integer sequence) {

--- a/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationService.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationService.java
@@ -31,6 +31,8 @@ public class SlotTimeCreationService extends BaseOpenmrsService {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
+    private static final List<String> INTRADAY_DOSE_FIELDS = Arrays.asList("morningDose", "afternoonDose", "eveningDose", "nightDose");
+
     public List<LocalDateTime> createSlotsStartTimeFrom(ScheduleMedicationRequest request, DrugOrder order) {
         if (request.getSlotStartTimeAsLocaltime() != null && request.getMedicationFrequency() == START_TIME_DURATION_FREQUENCY) {
             return getSlotsStartTimeWithStartTimeDurationFrequency(request, order);
@@ -49,7 +51,9 @@ public class SlotTimeCreationService extends BaseOpenmrsService {
         if (order.getFrequency() == null && request.getVariableDosageSequence() != null) {
             numberOfSlotsStartTimeToBeCreated = computeVdpNumberOfSlots(order, request.getVariableDosageSequence());
         } else if (order.getDose() == null && order.getFrequency() == null) {
-            numberOfSlotsStartTimeToBeCreated = getIntradayFrequencyPerDay(order) * order.getDuration();
+            numberOfSlotsStartTimeToBeCreated = order.getDuration() != null
+                ? getIntradayFrequencyPerDay(order) * order.getDuration()
+                : getIntradayFrequencyPerDay(order);
         } else {
             numberOfSlotsStartTimeToBeCreated = (int) (Math.ceil(order.getQuantity() / order.getDose()));
         }
@@ -255,13 +259,13 @@ public class SlotTimeCreationService extends BaseOpenmrsService {
             if (!dosing.isObject()) {
                 return 1;
             }
-            int count = (int) Arrays.asList("morningDose", "afternoonDose", "eveningDose", "nightDose")
-                .stream()
+            int count = (int) INTRADAY_DOSE_FIELDS.stream()
                 .filter(field -> dosing.path(field).asDouble(0) != 0)
                 .count();
             return count > 0 ? count : 1;
         } catch (Exception e) {
-            log.warn("Failed to derive intraday frequency per day for order {}", order.getUuid(), e);
+            log.warn("Failed to derive intraday frequency per day for order {} with dosingInstructions [{}]",
+                order.getUuid(), order.getDosingInstructions(), e);
             return 1;
         }
     }

--- a/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationService.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationService.java
@@ -129,7 +129,9 @@ public class SlotTimeCreationService extends BaseOpenmrsService {
         HashMap<String, DrugOrderSchedule> drugOrderScheduleHash= new HashMap<>();
         for (DrugOrder drugOrder : slotsByOrder.keySet()) {
             DrugOrderSchedule drugOrderSchedule = new DrugOrderSchedule();
-            boolean isIntradayOrder = drugOrder.getDose() == null && drugOrder.getFrequency() == null;
+            boolean isIntradayOrder = drugOrder.getDose() == null
+                    && drugOrder.getFrequency() == null
+                    && hasIntradayDoseFields(drugOrder.getDosingInstructions());
             if (drugOrder.getAsNeeded() || (drugOrder.getFrequency() == null && !isIntradayOrder) || drugOrder.getDuration() == null || drugOrder.getQuantity() == 0.0) {
                 drugOrderSchedule.setSlotStartTime(DateTimeUtil.convertLocalDateTimeToUTCEpoc(slotsByOrder.get(drugOrder).get(0).getStartDateTime()));
             }
@@ -249,14 +251,26 @@ public class SlotTimeCreationService extends BaseOpenmrsService {
             .collect(Collectors.toList());
     }
 
+    private boolean hasIntradayDoseFields(String dosingInstructions) {
+        if (dosingInstructions == null || dosingInstructions.trim().isEmpty()) return false;
+        try {
+            JsonNode dosing = MAPPER.readTree(dosingInstructions);
+            return dosing.isObject() && INTRADAY_DOSE_FIELDS.stream().anyMatch(dosing::has);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     private int getIntradayFrequencyPerDay(DrugOrder order) {
         try {
             String dosingInstructions = order.getDosingInstructions();
             if (dosingInstructions == null || dosingInstructions.trim().isEmpty()) {
+                log.warn("Intraday order {} has empty dosingInstructions; falling back to 1 slot/day", order.getUuid());
                 return 1;
             }
             JsonNode dosing = MAPPER.readTree(dosingInstructions);
             if (!dosing.isObject()) {
+                log.warn("Intraday order {} has non-object dosingInstructions; falling back to 1 slot/day", order.getUuid());
                 return 1;
             }
             int count = (int) INTRADAY_DOSE_FIELDS.stream()

--- a/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationServiceTest.java
+++ b/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationServiceTest.java
@@ -10,19 +10,22 @@ import org.openmrs.module.ipd.api.model.Slot;
 import org.openmrs.module.ipd.web.contract.ScheduleMedicationRequest;
 import org.openmrs.module.ipd.web.model.StageScheduleStatus;
 
+import org.openmrs.module.ipd.web.model.DrugOrderSchedule;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SlotTimeCreationServiceTest {
@@ -64,6 +67,24 @@ public class SlotTimeCreationServiceTest {
         order.setQuantity(quantity);
         order.setDose(dose);
         return order;
+    }
+
+    private DrugOrder buildIntradayDrugOrder(int duration, double morning, double afternoon, double evening, double night) {
+        DrugOrder order = new DrugOrder();
+        order.setDuration(duration);
+        order.setQuantity((morning + afternoon + evening + night) * duration);
+        order.setDosingInstructions(String.format(
+            "{\"morningDose\":%s,\"afternoonDose\":%s,\"eveningDose\":%s,\"nightDose\":%s}",
+            morning, afternoon, evening, night));
+        return order;
+    }
+
+    private Slot buildIntradaySlot(DrugOrder order, LocalDateTime startDateTime) {
+        Slot slot = new Slot();
+        slot.setOrder(order);
+        slot.setStartDateTime(startDateTime);
+        slot.setStatus(Slot.SlotStatus.SCHEDULED);
+        return slot;
     }
 
     // -----------------------------------------------------------------------
@@ -236,5 +257,184 @@ public class SlotTimeCreationServiceTest {
         List<StageScheduleStatus> result = slotTimeCreationService.buildStageSchedules(Collections.singletonList(slot));
 
         assertFalse(result.get(0).getAllAttended());
+    }
+
+    // -----------------------------------------------------------------------
+    // Intraday slot creation — createSlotsStartTimeFrom
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void shouldCreateCorrectSlots_ForIntraday2xDay_1DayDuration_NoPartialFirstDay() {
+        DrugOrder order = buildIntradayDrugOrder(1, 10.0, 0.0, 20.0, 0.0);
+        List<Long> dayWise = futureEpochList(2);
+        ScheduleMedicationRequest request = ScheduleMedicationRequest.builder()
+                .medicationFrequency(ScheduleMedicationRequest.MedicationFrequency.FIXED_SCHEDULE_FREQUENCY)
+                .dayWiseSlotsStartTime(dayWise)
+                .build();
+
+        List<LocalDateTime> result = slotTimeCreationService.createSlotsStartTimeFrom(request, order);
+
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    public void shouldCreateCorrectSlots_ForIntraday3xDay_3DayDuration_NoPartialFirstDay() {
+        DrugOrder order = buildIntradayDrugOrder(3, 5.0, 5.0, 5.0, 0.0);
+        List<Long> dayWise = futureEpochList(3);
+        ScheduleMedicationRequest request = ScheduleMedicationRequest.builder()
+                .medicationFrequency(ScheduleMedicationRequest.MedicationFrequency.FIXED_SCHEDULE_FREQUENCY)
+                .dayWiseSlotsStartTime(dayWise)
+                .build();
+
+        List<LocalDateTime> result = slotTimeCreationService.createSlotsStartTimeFrom(request, order);
+
+        assertEquals(9, result.size());
+    }
+
+    @Test
+    public void shouldCreateCorrectSlots_ForIntraday4xDay_2DayDuration_WithPartialFirstDay() {
+        DrugOrder order = buildIntradayDrugOrder(2, 62.5, 25.0, 37.5, 10.0);
+        List<Long> firstDay = futureEpochList(2);
+        List<Long> dayWise = futureEpochList(4);
+        List<Long> remaining = futureEpochList(2);
+        ScheduleMedicationRequest request = ScheduleMedicationRequest.builder()
+                .medicationFrequency(ScheduleMedicationRequest.MedicationFrequency.FIXED_SCHEDULE_FREQUENCY)
+                .firstDaySlotsStartTime(firstDay)
+                .dayWiseSlotsStartTime(dayWise)
+                .remainingDaySlotsStartTime(remaining)
+                .build();
+
+        List<LocalDateTime> result = slotTimeCreationService.createSlotsStartTimeFrom(request, order);
+
+        assertEquals(8, result.size());
+    }
+
+    @Test
+    public void shouldReturnEmpty_ForIntradayOrder_WhenNoSlotTimesProvided() {
+        DrugOrder order = buildIntradayDrugOrder(3, 10.0, 0.0, 20.0, 0.0);
+        ScheduleMedicationRequest request = ScheduleMedicationRequest.builder()
+                .medicationFrequency(ScheduleMedicationRequest.MedicationFrequency.FIXED_SCHEDULE_FREQUENCY)
+                .build();
+
+        List<LocalDateTime> result = slotTimeCreationService.createSlotsStartTimeFrom(request, order);
+
+        assertEquals(0, result.size());
+    }
+
+    // -----------------------------------------------------------------------
+    // getIntradayFrequencyPerDay — fallback behaviour (via slot count)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void shouldFallbackTo1Slot_ForIntradayOrder_WithNullDosingInstructions() {
+        DrugOrder order = new DrugOrder();
+        order.setDuration(1);
+        order.setQuantity(10.0);
+        List<Long> dayWise = futureEpochList(1);
+        ScheduleMedicationRequest request = ScheduleMedicationRequest.builder()
+                .medicationFrequency(ScheduleMedicationRequest.MedicationFrequency.FIXED_SCHEDULE_FREQUENCY)
+                .dayWiseSlotsStartTime(dayWise)
+                .build();
+
+        List<LocalDateTime> result = slotTimeCreationService.createSlotsStartTimeFrom(request, order);
+
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    public void shouldFallbackTo1Slot_ForIntradayOrder_WithFhirArrayDosingInstructions() {
+        DrugOrder order = new DrugOrder();
+        order.setDuration(1);
+        order.setQuantity(10.0);
+        order.setDosingInstructions("[{\"sequence\":1}]");
+        List<Long> dayWise = futureEpochList(1);
+        ScheduleMedicationRequest request = ScheduleMedicationRequest.builder()
+                .medicationFrequency(ScheduleMedicationRequest.MedicationFrequency.FIXED_SCHEDULE_FREQUENCY)
+                .dayWiseSlotsStartTime(dayWise)
+                .build();
+
+        List<LocalDateTime> result = slotTimeCreationService.createSlotsStartTimeFrom(request, order);
+
+        assertEquals(1, result.size());
+    }
+
+    // -----------------------------------------------------------------------
+    // getDrugOrderScheduledTime — edit mode reconstruction for intraday
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void shouldSetDayWiseSlotsStartTime_ForIntradayOrder_WithFullSchedule() {
+        DrugOrder order = buildIntradayDrugOrder(2, 10.0, 0.0, 20.0, 0.0);
+        LocalDate day1 = LocalDate.of(2026, 6, 1);
+        LocalDate day2 = LocalDate.of(2026, 6, 2);
+
+        List<Slot> slots = Arrays.asList(
+                buildIntradaySlot(order, day1.atTime(8, 0)),
+                buildIntradaySlot(order, day1.atTime(20, 0)),
+                buildIntradaySlot(order, day2.atTime(8, 0)),
+                buildIntradaySlot(order, day2.atTime(20, 0))
+        );
+
+        Map<DrugOrder, List<Slot>> slotsByOrder = new HashMap<>();
+        slotsByOrder.put(order, slots);
+
+        HashMap<String, DrugOrderSchedule> result = slotTimeCreationService.getDrugOrderScheduledTime(slotsByOrder);
+        DrugOrderSchedule schedule = result.get(order.getUuid());
+
+        assertNotNull("dayWiseSlotsStartTime should be set for full intraday schedule", schedule.getDayWiseSlotsStartTime());
+        assertEquals(2, schedule.getDayWiseSlotsStartTime().size());
+        assertNull("firstDaySlotsStartTime should be null when first day is complete", schedule.getFirstDaySlotsStartTime());
+    }
+
+    @Test
+    public void shouldSetFirstDayAndRemainingSlots_ForIntradayOrder_WithPartialFirstDay() {
+        DrugOrder order = buildIntradayDrugOrder(3, 10.0, 0.0, 20.0, 0.0);
+        LocalDate day1 = LocalDate.of(2026, 6, 1);
+        LocalDate day2 = LocalDate.of(2026, 6, 2);
+        LocalDate day3 = LocalDate.of(2026, 6, 3);
+        LocalDate day4 = LocalDate.of(2026, 6, 4);
+
+        List<Slot> slots = Arrays.asList(
+                buildIntradaySlot(order, day1.atTime(20, 0)),
+                buildIntradaySlot(order, day2.atTime(8, 0)),
+                buildIntradaySlot(order, day2.atTime(20, 0)),
+                buildIntradaySlot(order, day3.atTime(8, 0)),
+                buildIntradaySlot(order, day3.atTime(20, 0)),
+                buildIntradaySlot(order, day4.atTime(8, 0))
+        );
+
+        Map<DrugOrder, List<Slot>> slotsByOrder = new HashMap<>();
+        slotsByOrder.put(order, slots);
+
+        HashMap<String, DrugOrderSchedule> result = slotTimeCreationService.getDrugOrderScheduledTime(slotsByOrder);
+        DrugOrderSchedule schedule = result.get(order.getUuid());
+
+        assertNotNull("firstDaySlotsStartTime should be set for partial first day", schedule.getFirstDaySlotsStartTime());
+        assertEquals(1, schedule.getFirstDaySlotsStartTime().size());
+        assertNotNull("dayWiseSlotsStartTime should be set from second day", schedule.getDayWiseSlotsStartTime());
+        assertEquals(2, schedule.getDayWiseSlotsStartTime().size());
+        assertNotNull("remainingDaySlotsStartTime should hold carry-over slot", schedule.getRemainingDaySlotsStartTime());
+        assertEquals(1, schedule.getRemainingDaySlotsStartTime().size());
+    }
+
+    @Test
+    public void shouldNotSetSlotStartTime_ForIntradayOrder_EvenThoughFrequencyIsNull() {
+        DrugOrder order = buildIntradayDrugOrder(1, 10.0, 0.0, 20.0, 0.0);
+        LocalDate day1 = LocalDate.of(2026, 6, 1);
+
+        List<Slot> slots = Arrays.asList(
+                buildIntradaySlot(order, day1.atTime(8, 0)),
+                buildIntradaySlot(order, day1.atTime(20, 0))
+        );
+
+        Map<DrugOrder, List<Slot>> slotsByOrder = new HashMap<>();
+        slotsByOrder.put(order, slots);
+
+        HashMap<String, DrugOrderSchedule> result = slotTimeCreationService.getDrugOrderScheduledTime(slotsByOrder);
+        DrugOrderSchedule schedule = result.get(order.getUuid());
+
+        assertNull("slotStartTime should NOT be set for intraday orders even though frequency is null",
+                schedule.getSlotStartTime());
+        assertNotNull("dayWiseSlotsStartTime should be set instead", schedule.getDayWiseSlotsStartTime());
     }
 }

--- a/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationServiceTest.java
+++ b/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/SlotTimeCreationServiceTest.java
@@ -321,6 +321,20 @@ public class SlotTimeCreationServiceTest {
         assertEquals(0, result.size());
     }
 
+    @Test
+    public void shouldNotThrow_ForIntradayOrder_WithNullDuration() {
+        DrugOrder order = buildIntradayDrugOrder(1, 10.0, 0.0, 20.0, 0.0);
+        order.setDuration(null);
+        ScheduleMedicationRequest request = ScheduleMedicationRequest.builder()
+                .medicationFrequency(ScheduleMedicationRequest.MedicationFrequency.FIXED_SCHEDULE_FREQUENCY)
+                .dayWiseSlotsStartTime(futureEpochList(2))
+                .build();
+
+        List<LocalDateTime> result = slotTimeCreationService.createSlotsStartTimeFrom(request, order);
+
+        assertEquals(2, result.size());
+    }
+
     // -----------------------------------------------------------------------
     // getIntradayFrequencyPerDay — fallback behaviour (via slot count)
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix NPE in `getSlotsStartTimeWithFixedScheduleFrequency` for intraday orders where `order.getDose()` and `order.getFrequency()` are null — slot count now derived from `getIntradayFrequencyPerDay(order) × duration`
- Fix edit mode reconstruction in `getDrugOrderScheduledTime` — intraday orders were incorrectly routed to the `slotStartTime` branch because `frequency == null`; now correctly builds `dayWiseSlotsStartTime`/`firstDaySlotsStartTime`/`remainingDaySlotsStartTime` from saved slots
- New `getIntradayFrequencyPerDay` helper reads `morningDose`/`afternoonDose`/`eveningDose`/`nightDose` from `order.getDosingInstructions()` — same canonical source as the frontend, with null/empty/non-object guards

## Test plan

- [ ] Schedule an intraday medication (2x, 3x, 4x per day) — verify correct number of slots created
- [ ] Edit a previously scheduled intraday medication — verify saved times are pre-populated in the slider
- [ ] Verify no NPE when saving intraday medication with `dose=null`
- [ ] All existing tests pass: `./mvnw clean package`

🤖 Generated with [Claude Code](https://claude.com/claude-code)