### PR TITLE
Avni|bugfix-108755| Refactor resposne structure to correctly update the updatecompletedschedule toggle value

### DIFF
--- a/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/IPDVisitServiceImpl.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/web/service/impl/IPDVisitServiceImpl.java
@@ -18,6 +18,7 @@ import org.openmrs.module.ipd.api.model.ServiceType;
 import org.openmrs.module.ipd.api.model.Slot;
 import org.openmrs.module.ipd.api.model.*;
 import org.openmrs.module.ipd.api.service.ReferenceService;
+import org.openmrs.module.ipd.api.service.ScheduleService;
 import org.openmrs.module.ipd.api.service.SlotService;
 import org.openmrs.module.ipd.api.util.IPDConstants;
 import org.openmrs.module.ipd.web.service.IPDVisitService;
@@ -44,6 +45,7 @@ public class IPDVisitServiceImpl implements IPDVisitService {
     private ReferenceService referenceService;
     private VisitService visitService;
     private SlotService slotService;
+    private ScheduleService scheduleService;
 
     @Autowired
     public IPDVisitServiceImpl(BahmniDrugOrderService drugOrderService,
@@ -53,7 +55,8 @@ public class IPDVisitServiceImpl implements IPDVisitService {
                                ConceptService conceptService,
                                ReferenceService referenceService,
                                VisitService visitService,
-                               SlotService slotService) {
+                               SlotService slotService,
+                               ScheduleService scheduleService) {
         this.drugOrderService = drugOrderService;
         this.ipdScheduleService = ipdScheduleService;
         this.slotTimeCreationService = slotTimeCreationService;
@@ -63,6 +66,7 @@ public class IPDVisitServiceImpl implements IPDVisitService {
         this.referenceService = referenceService;
         this.visitService = visitService;
         this.slotService = slotService;
+        this.scheduleService = scheduleService;
     }
 
 
@@ -101,7 +105,7 @@ public class IPDVisitServiceImpl implements IPDVisitService {
             Collection<BahmniObservation> orderAttributeObs = bahmniObsService.observationsFor(patientUuid, getOrdAttributeConcepts(), null, null, false, null, null, null);
             List<BahmniDrugOrder> bahmniDrugOrders = bahmniDrugOrderMapper.mapToResponse(drugOrdersFiltered, orderAttributeObs, drugOrderMap , null);
             bahmniDrugOrders=sortDrugOrdersAccordingToTheirSortWeight(bahmniDrugOrders);
-            Map<String, DrugOrderSchedule> drugOrderScheduleByOrders = getDrugOrderScheduleForOrders(patientUuid, bahmniDrugOrders);
+            Map<String, DrugOrderSchedule> drugOrderScheduleByOrders = getDrugOrderScheduleForOrders(patientUuid, bahmniDrugOrders, currentVisit);
 
             return bahmniDrugOrders.stream().map(bahmniDrugOrder -> IPDDrugOrder.createFrom(bahmniDrugOrder,drugOrderScheduleByOrders.get(bahmniDrugOrder.getUuid()))).collect(Collectors.toList());
 
@@ -110,7 +114,7 @@ public class IPDVisitServiceImpl implements IPDVisitService {
         }
     }
 
-    private Map<String, DrugOrderSchedule> getDrugOrderScheduleForOrders(String patientUuid, List<BahmniDrugOrder> bahmniDrugOrders) {
+    private Map<String, DrugOrderSchedule> getDrugOrderScheduleForOrders(String patientUuid, List<BahmniDrugOrder> bahmniDrugOrders, Visit currentVisit) {
         List<String> orderUuids = bahmniDrugOrders.stream()
                 .map(BahmniDrugOrder::getUuid)
                 .collect(Collectors.toList());
@@ -130,6 +134,13 @@ public class IPDVisitServiceImpl implements IPDVisitService {
                 .collect(Collectors.groupingBy(slot -> (DrugOrder) slot.getOrder()));
 
         Map<String, DrugOrderSchedule> drugOrderScheduleByOrders = slotTimeCreationService.getDrugOrderScheduledTime(groupedByOrders);
+
+        Schedule visitSchedule = scheduleService.getScheduleByVisit(currentVisit);
+        Boolean isUpdateCompleteSchedule = visitSchedule != null
+                && Boolean.TRUE.equals(visitSchedule.getIsUpdateCompleteSchedule());
+        drugOrderScheduleByOrders.values().forEach(
+                drugOrderSchedule -> drugOrderSchedule.setIsUpdateCompleteSchedule(isUpdateCompleteSchedule)
+        );
 
 
         return drugOrderScheduleByOrders;

--- a/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/IPDVisitServiceImplTest.java
+++ b/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/IPDVisitServiceImplTest.java
@@ -14,8 +14,10 @@ import org.openmrs.Visit;
 import org.openmrs.VisitType;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.VisitService;
+import org.openmrs.module.ipd.api.model.Schedule;
 import org.openmrs.module.ipd.api.model.ServiceType;
 import org.openmrs.module.ipd.api.service.ReferenceService;
+import org.openmrs.module.ipd.api.service.ScheduleService;
 import org.openmrs.module.ipd.api.service.SlotService;
 import org.openmrs.module.ipd.web.model.DrugOrderSchedule;
 import org.openmrs.module.ipd.web.service.IPDScheduleService;
@@ -32,6 +34,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -51,6 +54,7 @@ public class IPDVisitServiceImplTest {
     @Mock private ReferenceService referenceService;
     @Mock private VisitService visitService;
     @Mock private SlotService slotService;
+    @Mock private ScheduleService scheduleService;
 
     private Patient patient;
 
@@ -162,6 +166,59 @@ public class IPDVisitServiceImplTest {
         ArgumentCaptor<List<String>> visitUuidsCaptor = ArgumentCaptor.forClass(List.class);
         verify(drugOrderService).getPrescribedDrugOrders(visitUuidsCaptor.capture(), any(), any(), any(), any(), any(), any());
         assertEquals(Arrays.asList("current-uuid", "in-absentia-uuid", "lab-visit-uuid"), visitUuidsCaptor.getValue());
+    }
+
+    @Test
+    public void shouldSetUpdateCompleteScheduleAsTrue_WhenVisitScheduleFlagIsTrue() {
+        Visit currentVisit = visit("current-uuid", "IPD", now(), null);
+        Visit inAbsentiaVisit = visit("in-absentia-uuid", "In Absentia", now() - HOUR, null);
+
+        DrugOrderSchedule drugOrderSchedule = org.mockito.Mockito.mock(DrugOrderSchedule.class);
+        HashMap<String, DrugOrderSchedule> byOrder = new HashMap<>();
+        byOrder.put("order-1", drugOrderSchedule);
+
+        Schedule visitSchedule = new Schedule();
+        visitSchedule.setIsUpdateCompleteSchedule(true);
+
+        when(visitService.getVisitByUuid("current-uuid")).thenReturn(currentVisit);
+        when(visitService.getVisitsByPatient(patient)).thenReturn(Arrays.asList(inAbsentiaVisit, currentVisit));
+        when(drugOrderService.getPrescribedDrugOrders(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(Collections.emptyList());
+        when(drugOrderService.getDiscontinuedDrugOrders(any())).thenReturn(Collections.emptyMap());
+        when(bahmniObsService.observationsFor(any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(Collections.emptyList());
+        when(ipdScheduleService.getMedicationSlots(anyString(), any(ServiceType.class), anyList())).thenReturn(Collections.emptyList());
+        when(slotTimeCreationService.getDrugOrderScheduledTime(any())).thenReturn(byOrder);
+        when(scheduleService.getScheduleByVisit(currentVisit)).thenReturn(visitSchedule);
+
+        service.getPrescribedOrders("current-uuid", true, null, null, null, true);
+
+        verify(drugOrderSchedule, times(1)).setIsUpdateCompleteSchedule(true);
+    }
+
+    @Test
+    public void shouldSetUpdateCompleteScheduleAsFalse_WhenVisitScheduleIsMissing() {
+        Visit currentVisit = visit("current-uuid", "IPD", now(), null);
+        Visit inAbsentiaVisit = visit("in-absentia-uuid", "In Absentia", now() - HOUR, null);
+
+        DrugOrderSchedule drugOrderSchedule = org.mockito.Mockito.mock(DrugOrderSchedule.class);
+        HashMap<String, DrugOrderSchedule> byOrder = new HashMap<>();
+        byOrder.put("order-1", drugOrderSchedule);
+
+        when(visitService.getVisitByUuid("current-uuid")).thenReturn(currentVisit);
+        when(visitService.getVisitsByPatient(patient)).thenReturn(Arrays.asList(inAbsentiaVisit, currentVisit));
+        when(drugOrderService.getPrescribedDrugOrders(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(Collections.emptyList());
+        when(drugOrderService.getDiscontinuedDrugOrders(any())).thenReturn(Collections.emptyMap());
+        when(bahmniObsService.observationsFor(any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(Collections.emptyList());
+        when(ipdScheduleService.getMedicationSlots(anyString(), any(ServiceType.class), anyList())).thenReturn(Collections.emptyList());
+        when(slotTimeCreationService.getDrugOrderScheduledTime(any())).thenReturn(byOrder);
+        when(scheduleService.getScheduleByVisit(currentVisit)).thenReturn(null);
+
+        service.getPrescribedOrders("current-uuid", true, null, null, null, true);
+
+        verify(drugOrderSchedule, times(1)).setIsUpdateCompleteSchedule(false);
     }
 
     private Visit visit(String uuid, String visitTypeName, long startTime, Long stopTime) {


### PR DESCRIPTION
isUpdateCompleteSchedule Persistence + Response Propagation
**Issue**
Toggle state (“Update Complete Schedule”) was not reliably restored on edit.
API sometimes returned isUpdateCompleteSchedule: null, causing frontend ambiguity/inference.
Root Cause
Toggle state was saved at schedule level, but not consistently surfaced back on each drugOrderSchedule in visit response.
**Fix**
Backend now explicitly propagates visit schedule toggle state to each DrugOrderSchedule response.
Ensures frontend receives a deterministic boolean for edit restoration (instead of null/implicit inference paths).