### PR TITLE
Hive-128516|Ramadevi|Fix non-IPD medications not showing in Care View To Be Acknowledged list

### DIFF
--- a/api/src/main/java/org/openmrs/module/ipd/api/dao/impl/HibernateWardDAO.java
+++ b/api/src/main/java/org/openmrs/module/ipd/api/dao/impl/HibernateWardDAO.java
@@ -48,18 +48,7 @@ public class HibernateWardDAO implements WardDAO {
     public List<AdmittedPatient> getAdmittedPatients(Location location, Provider provider, Date dateTime, String sortBy) {
         Session session = this.sessionFactory.getCurrentSession();
         try {
-            String queryString = "select NEW org.openmrs.module.ipd.api.model.AdmittedPatient(assignment," +
-                    "(COUNT(DISTINCT o.orderId) - COUNT (DISTINCT s.order.orderId)), careTeam)" +
-                    "from org.openmrs.module.bedmanagement.entity.BedPatientAssignment assignment " +
-                    "JOIN org.openmrs.Visit v on v.patient = assignment.patient " +
-                    "JOIN org.openmrs.Encounter e on e.visit = v " +
-                    "LEFT JOIN CareTeam careTeam on careTeam.visit = v " +
-                    "JOIN org.openmrs.module.bedmanagement.entity.BedLocationMapping locmap on locmap.bed = assignment.bed " +
-                    "JOIN org.openmrs.Location l on locmap.location = l " +
-                    "LEFT JOIN careTeam.participants ctp ON ctp.voided = 0 " +
-                    "LEFT JOIN org.openmrs.Order o on o.encounter = e and o.dateStopped is null and o.action!='DISCONTINUE' and o.careSetting.careSettingId = 2 " +
-                    "LEFT JOIN Slot s on s.order = o " +
-                    "where assignment.endDatetime is null and v.stopDatetime is null ";
+            String queryString = getAdmittedPatientsSelectClause();
 
             if(location != null){
                 queryString += "and l.parentLocation = :location ";
@@ -92,6 +81,8 @@ public class HibernateWardDAO implements WardDAO {
             if (dateTime != null) {
                 query.setParameter("dateTime", dateTime);
             }
+
+            query.setParameter("now", new Date());
 
             return query.getResultList();
         }
@@ -149,18 +140,7 @@ public class HibernateWardDAO implements WardDAO {
         try {
             Session session = sessionFactory.getCurrentSession();
 
-            String selectQuery = "select NEW org.openmrs.module.ipd.api.model.AdmittedPatient(assignment, " +
-                    "(COUNT(DISTINCT o.orderId) - COUNT(DISTINCT s.order.orderId)), careTeam) " +
-                    "from org.openmrs.module.bedmanagement.entity.BedPatientAssignment assignment " +
-                    "JOIN org.openmrs.Visit v on v.patient = assignment.patient " +
-                    "JOIN org.openmrs.Patient p on assignment.patient = p " +
-                    "JOIN org.openmrs.Person pr on pr.personId = p.patientId " +
-                    "JOIN org.openmrs.Encounter e on e.visit = v " +
-                    "LEFT JOIN CareTeam careTeam on careTeam.visit = v " +
-                    "JOIN org.openmrs.module.bedmanagement.entity.BedLocationMapping locmap on locmap.bed = assignment.bed " +
-                    "JOIN org.openmrs.Location l on locmap.location = l " +
-                    "LEFT JOIN org.openmrs.Order o on o.encounter = e and o.dateStopped is null and o.action!='DISCONTINUE' and o.careSetting.careSettingId = 2 " +
-                    "LEFT JOIN Slot s on s.order = o ";
+            String selectQuery = getSearchAdmittedPatientsSelectClause();
 
 
             // Construct additional joins and where clause based on search keys
@@ -178,6 +158,7 @@ public class HibernateWardDAO implements WardDAO {
 
             // Set parameters
             query.setParameter("location", location);
+            query.setParameter("now", new Date());
             setQueryParameters(query, searchKeys, searchValue);
 
             return query.getResultList();
@@ -247,6 +228,34 @@ public class HibernateWardDAO implements WardDAO {
         return whereClause.append(" or ");
     }
 
+    static String getAdmittedPatientsSelectClause() {
+        return "select NEW org.openmrs.module.ipd.api.model.AdmittedPatient(assignment," +
+                "(COUNT(DISTINCT o.orderId) - COUNT (DISTINCT s.order.orderId)), careTeam)" +
+                "from org.openmrs.module.bedmanagement.entity.BedPatientAssignment assignment " +
+                "JOIN org.openmrs.Visit v on v.patient = assignment.patient " +
+                "JOIN org.openmrs.Encounter e on e.visit = v " +
+                "LEFT JOIN CareTeam careTeam on careTeam.visit = v " +
+                "JOIN org.openmrs.module.bedmanagement.entity.BedLocationMapping locmap on locmap.bed = assignment.bed " +
+                "JOIN org.openmrs.Location l on locmap.location = l " +
+                "LEFT JOIN careTeam.participants ctp ON ctp.voided = 0 " +
+                "LEFT JOIN org.openmrs.Order o on o.patient = assignment.patient and o.voided = false and o.action!='DISCONTINUE' and ((o.dateStopped is null and o.autoExpireDate is null) or (o.dateStopped is null and o.autoExpireDate >= :now) or o.dateStopped >= :now) " +
+                "LEFT JOIN Slot s on s.order = o " +
+                "where assignment.endDatetime is null and v.stopDatetime is null ";
+    }
 
+    static String getSearchAdmittedPatientsSelectClause() {
+        return "select NEW org.openmrs.module.ipd.api.model.AdmittedPatient(assignment, " +
+                "(COUNT(DISTINCT o.orderId) - COUNT(DISTINCT s.order.orderId)), careTeam) " +
+                "from org.openmrs.module.bedmanagement.entity.BedPatientAssignment assignment " +
+                "JOIN org.openmrs.Visit v on v.patient = assignment.patient " +
+                "JOIN org.openmrs.Patient p on assignment.patient = p " +
+                "JOIN org.openmrs.Person pr on pr.personId = p.patientId " +
+                "JOIN org.openmrs.Encounter e on e.visit = v " +
+                "LEFT JOIN CareTeam careTeam on careTeam.visit = v " +
+                "JOIN org.openmrs.module.bedmanagement.entity.BedLocationMapping locmap on locmap.bed = assignment.bed " +
+                "JOIN org.openmrs.Location l on locmap.location = l " +
+                "LEFT JOIN org.openmrs.Order o on o.patient = assignment.patient and o.voided = false and o.action!='DISCONTINUE' and ((o.dateStopped is null and o.autoExpireDate is null) or (o.dateStopped is null and o.autoExpireDate >= :now) or o.dateStopped >= :now) " +
+                "LEFT JOIN Slot s on s.order = o ";
+    }
 
 }

--- a/api/src/test/java/org/openmrs/module/ipd/api/dao/impl/HibernateWardDAOUnitTest.java
+++ b/api/src/test/java/org/openmrs/module/ipd/api/dao/impl/HibernateWardDAOUnitTest.java
@@ -1,0 +1,92 @@
+package org.openmrs.module.ipd.api.dao.impl;
+
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HibernateWardDAOUnitTest {
+
+    private static final String ACTIVE_ORDER_JOIN =
+            "LEFT JOIN org.openmrs.Order o on o.patient = assignment.patient " +
+                    "and o.voided = false and o.action!='DISCONTINUE' " +
+                    "and ((o.dateStopped is null and o.autoExpireDate is null) " +
+                    "or (o.dateStopped is null and o.autoExpireDate >= :now) " +
+                    "or o.dateStopped >= :now)";
+
+    @Test
+    public void shouldJoinOrdersByPatientInsteadOfEncounterInAdmittedPatientsQuery() {
+        String query = HibernateWardDAO.getAdmittedPatientsSelectClause();
+
+        assertTrue(query.contains("o.patient = assignment.patient"));
+        assertFalse(query.contains("o.encounter"));
+    }
+
+    @Test
+    public void shouldJoinOrdersByPatientInsteadOfEncounterInSearchAdmittedPatientsQuery() {
+        String query = HibernateWardDAO.getSearchAdmittedPatientsSelectClause();
+
+        assertTrue(query.contains("o.patient = assignment.patient"));
+        assertFalse(query.contains("o.encounter"));
+    }
+
+    @Test
+    public void shouldExcludeVoidedAndDiscontinuedOrdersInAdmittedPatientsQuery() {
+        String query = HibernateWardDAO.getAdmittedPatientsSelectClause();
+
+        assertTrue(query.contains("o.voided = false"));
+        assertTrue(query.contains("o.action!='DISCONTINUE'"));
+    }
+
+    @Test
+    public void shouldExcludeVoidedAndDiscontinuedOrdersInSearchAdmittedPatientsQuery() {
+        String query = HibernateWardDAO.getSearchAdmittedPatientsSelectClause();
+
+        assertTrue(query.contains("o.voided = false"));
+        assertTrue(query.contains("o.action!='DISCONTINUE'"));
+    }
+
+    @Test
+    public void shouldUseActiveOrderDateLogicInAdmittedPatientsQuery() {
+        String query = HibernateWardDAO.getAdmittedPatientsSelectClause();
+
+        assertTrue(query.contains("o.dateStopped is null"));
+        assertTrue(query.contains("o.autoExpireDate is null"));
+        assertTrue(query.contains("o.autoExpireDate >= :now"));
+        assertTrue(query.contains("o.dateStopped >= :now"));
+    }
+
+    @Test
+    public void shouldUseActiveOrderDateLogicInSearchAdmittedPatientsQuery() {
+        String query = HibernateWardDAO.getSearchAdmittedPatientsSelectClause();
+
+        assertTrue(query.contains("o.dateStopped is null"));
+        assertTrue(query.contains("o.autoExpireDate is null"));
+        assertTrue(query.contains("o.autoExpireDate >= :now"));
+        assertTrue(query.contains("o.dateStopped >= :now"));
+    }
+
+    @Test
+    public void shouldSubtractSlottedOrdersInAdmittedPatientsQuery() {
+        String query = HibernateWardDAO.getAdmittedPatientsSelectClause();
+
+        assertTrue(query.contains("COUNT(DISTINCT o.orderId)"));
+        assertTrue(query.contains("COUNT (DISTINCT s.order.orderId)"));
+        assertTrue(query.contains("LEFT JOIN Slot s on s.order = o "));
+    }
+
+    @Test
+    public void shouldSubtractSlottedOrdersInSearchAdmittedPatientsQuery() {
+        String query = HibernateWardDAO.getSearchAdmittedPatientsSelectClause();
+
+        assertTrue(query.contains("COUNT(DISTINCT o.orderId)"));
+        assertTrue(query.contains("COUNT(DISTINCT s.order.orderId)"));
+        assertTrue(query.contains("LEFT JOIN Slot s on s.order = o "));
+    }
+
+    @Test
+    public void shouldKeepFullActiveOrderRuleInBothQueryBuilders() {
+        assertTrue(HibernateWardDAO.getAdmittedPatientsSelectClause().contains(ACTIVE_ORDER_JOIN));
+        assertTrue(HibernateWardDAO.getSearchAdmittedPatientsSelectClause().contains(ACTIVE_ORDER_JOIN));
+    }
+}


### PR DESCRIPTION
The New Medication(s) count displayed in the Care View was incorrect in some scenarios because medication orders were not being evaluated consistently based on their active/inactive status.

Expected Behavior

The Care View should display the number of new active medication orders for the patient.

For example:

If 1 new medication is added → 1 New Medication(s)
If 4 new medications are added → 4 New Medication(s)
If there are no new medications → the New Medication(s) indicator should not be displayed.

Stopped/inactive medication orders should not be included in the new medication count.

Fix

Updated the medication order filtering/counting logic to use the correct active medication order semantics, so that the Care View displays the accurate number of new medications.

Validation
Verified the new medication count for single and multiple medication orders.
Verified that inactive/stopped medication orders are not counted.
Added/updated unit test coverage for the new medication count behavior.

HIVE :https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?actionId=KdvLw5TFdM3JrjxeC